### PR TITLE
Apply fix-ups and fix warnings

### DIFF
--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -26,8 +26,8 @@ fn main() {
 
     print_metadata(&doc);
 
-    let mut output: Box<OutputDev> = match output_kind.as_ref() {
-        "txt" => Box::new(PlainTextOutput::new(&mut output_file as (&mut std::io::Write))),
+    let mut output: Box<dyn OutputDev> = match output_kind.as_ref() {
+        "txt" => Box::new(PlainTextOutput::new(&mut output_file as &mut dyn std::io::Write)),
         "html" => Box::new(HTMLOutput::new(&mut output_file)),
         "svg" => Box::new(SVGOutput::new(&mut output_file)),
         _ => panic!(),

--- a/src/encodings.rs
+++ b/src/encodings.rs
@@ -772,6 +772,7 @@ pub const WIN_ANSI_ENCODING: [Option<&str>; 256] = [
   Some("thorn"),
   Some("ydieresis")];
 
+#[allow(dead_code)]
 pub const STANDARD_ENCODING: [Option<&str>; 256] = [
   None,
   None,
@@ -1031,6 +1032,7 @@ pub const STANDARD_ENCODING: [Option<&str>; 256] = [
   None
 ];
 
+#[allow(dead_code)]
 pub const EXPERT_ENCODING: [Option<&str>; 256] = [
   None,
   None,
@@ -1289,6 +1291,7 @@ pub const EXPERT_ENCODING: [Option<&str>; 256] = [
   Some("Thornsmall"),
   Some("Ydieresissmall")];
 
+#[allow(dead_code)]
 pub const SYMBOL_ENCODING: [Option<&str>; 256] = [
   None,
   None,
@@ -1547,6 +1550,7 @@ pub const SYMBOL_ENCODING: [Option<&str>; 256] = [
   Some("bracerightbt"),
   None];
 
+#[allow(dead_code)]
 pub const ZAPFDINGBATS_ENCODING: [Option<&str>; 256] = [
   None,
   None,

--- a/src/glyphnames.rs
+++ b/src/glyphnames.rs
@@ -4695,6 +4695,6 @@ pub fn name_to_unicode(name: &str) -> Option<u16> {
 ("zuhiragana", 0x305a),
 ("zukatakana", 0x30ba)
     ];
-    let result = names.binary_search_by_key(&name, |&(name,code)| &name);
+    let result = names.binary_search_by_key(&name, |&(name,_code)| &name);
     result.ok().map(|indx| names[indx].1)
 }

--- a/src/zapfglyphnames.rs
+++ b/src/zapfglyphnames.rs
@@ -205,6 +205,6 @@ pub fn zapfdigbats_names_to_unicode(name: &str) -> Option<u16> {
         ("space", 0x0020),
     ];
 
-    let result = names.binary_search_by_key(&name, |&(name,code)| &name);
+    let result = names.binary_search_by_key(&name, |&(name,_code)| &name);
     result.ok().map(|indx| names[indx].1)
 }


### PR DESCRIPTION
Hey,

I just stumbled across this repository and I think I might find that crate useful in future. Thus, I took the liberty to fix a bunch of warnings the compiler displayed during compilation.

There seem to be lots of unused functions. Some were obviously not needed, but others are not obvious, since they might be needed in future. I silenced the warnings for these.

Also, I took the liberty to introduce an Error type and make all the trait functions return a `Result`. I think that will be useful for proper error propagation.

The code is unformatted. Usually, I run `cargo format --all` on my  rust code, but for easier review, I didn't do that here.

Hope you find those changes useful,

Kind regards,
Olaf