### PR TITLE
Changed the panic for a empty value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1187,7 +1187,7 @@ fn apply_state(gs: &mut GraphicsState, state: &Dictionary) {
                         panic!("unexpected smask name")
                     }
                 }
-                _ => { panic!("unexpected smask type {:?}", v) }
+                _ => { gs.smask = None }
             }}
             b"Type" => { match v {
                 &Object::Name(ref name) => {


### PR DESCRIPTION
As we want to see the text if the mask is not found I just used None for them, this way we can see the text and not panic the application.