### PR TITLE
fix: Use `get` instead of `[]` to avoid panic when key is missing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,7 +466,7 @@ impl<'a> PdfSimpleFont<'a> {
                                 }
                                 dlog!("{} = {} ({:?})", code, name, unicode);
                                 if let Some(ref mut unicode_map) = unicode_map {
-                                    dlog!("{} {}", code, unicode_map[&(code as u32)]);
+                                    dlog!("{} {}", code, unicode_map.get(&(code as u32)));
                                 }
                                 code += 1;
                             }


### PR DESCRIPTION
Fix #76 