### PR TITLE
Added support for missing colour spaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1449,7 +1449,10 @@ fn make_colorspace<'a>(doc: &'a Document, name: &[u8], resources: &'a Dictionary
                     }
                     "Pattern" => {
                         ColorSpace::Pattern
-                    }
+                    },
+                    "DeviceGray" => ColorSpace::DeviceGray,
+                    "DeviceRGB" => ColorSpace::DeviceRGB,
+                    "DeviceCMYK" => ColorSpace::DeviceCMYK,
                     _ => {
                         panic!("color_space {:?} {:?} {:?}", name, cs_name, cs)
                     }


### PR DESCRIPTION
I don't know that much about the PDF Specification, but I found [this PDF file](http://h10032.www1.hp.com/ctg/Manual/c06189562.pdf) from HP that had a "DeviceGray" colour space with a different "name" in the contest of the modified function, so the match at the start of the function doesn't work for that case.

If this change is wrong let me know. I just analysed the lib with WinDbg, check the values of variables while running, and add those (apparently) missing values.

Hava a nice day!