### PR TITLE
Upgraded lopdf version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = true
 adobe-cmap-parser = "0.4.0"
 encoding = "0.2.33"
 euclid = "0.20.5"
-lopdf = {version = "0.30", default-features = false, features = ["nom_parser"]}
+lopdf = {version = "0.32", default-features = false, features = ["nom_parser"]}
 postscript = "0.14"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"


### PR DESCRIPTION
The 0.32 version of lopdf contains a few fixes and without them some PDF files cannot be opened.
