### PR TITLE
Fix panic by setting default_width to Some(1.0)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ impl<'a> PdfSimpleFont<'a> {
             panic!("no widths");
         }
 
-        PdfSimpleFont {doc, font, widths: width_map, encoding: encoding_table, default_width: None, unicode_map}
+        PdfSimpleFont {doc, font, widths: width_map, encoding: encoding_table, default_width: Some(1.0), unicode_map}
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
default_width is never changed from its initial value of None, so for pdfs that end up unwrapping this value, it always results in a panic. Therefore, assume a default_width of Some(1.0)

This change yields correct results for my pdf that was previously panicking.