### PR TITLE
Fix crashing debug output in PdfSimpleFont

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,8 +491,12 @@ impl<'a> PdfSimpleFont<'a> {
                         }
                     }
                 }
-                let name = pdf_to_utf8(encoding.get(b"Type").unwrap().as_name().unwrap());
-                dlog!("name: {}", name);
+                let name_encoded = encoding.get(b"Type");
+                if let Ok(Object::Name(name)) = name_encoded {
+                    dlog!("name: {}", pdf_to_utf8(name));
+                } else {
+                    dlog!("name not found");
+                }
 
                 encoding_table = Some(table);
             }


### PR DESCRIPTION
Same issue and change as PR #29, but the panicking code was duplicated in PdfSimpleFont and wasn't caught by the original PR. So this finishes removing the debug print panic.