### PR TITLE
refactor: apply common rust patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 tests/docs_cache
 /*.pdf
 /*.txt
+tags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,13 @@ debug = true
 adobe-cmap-parser = "0.4.1"
 encoding_rs = "0.8.34"
 euclid = "0.20.5"
-lopdf = {version = "0.34", default-features = false, features = ["nom_parser"]}
+lopdf = { version = "0.34", default-features = false, features = [
+  "nom_parser",
+] }
 postscript = "0.14"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"
 
 [dev-dependencies]
 ureq = "2.6.2"
+tempfile = "3.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Jeff Muizelaar <jmuizelaar@mozilla.com>"]
 description = "A library to extract content from pdfs"
 documentation = "https://docs.rs/crate/pdf-extract/"
-edition = "2018"
+edition = "2021"
 keywords = ["pdf2text", "text", "pdf", "pdf2txt"]
 license = "MIT"
 name = "pdf-extract"
@@ -15,15 +15,15 @@ debug = true
 
 [dependencies]
 adobe-cmap-parser = "0.4.1"
-encoding_rs = "0.8.34"
-euclid = "0.20.5"
+encoding_rs = "0.8.35"
+euclid = "0.20.14"
 lopdf = { version = "0.34", default-features = false, features = [
   "nom_parser",
 ] }
-postscript = "0.14"
+postscript = "0.18.4"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"
 
 [dev-dependencies]
-ureq = "2.6.2"
+ureq = "2.12.1"
 tempfile = "3.15.0"

--- a/examples/extract.rs
+++ b/examples/extract.rs
@@ -1,13 +1,13 @@
-extern crate pdf_extract;
 extern crate lopdf;
+extern crate pdf_extract;
 
+use lopdf::Document;
+use pdf_extract::{output_doc, print_metadata, HTMLOutput, OutputDev, PlainTextOutput, SVGOutput};
 use std::env;
-use std::path::PathBuf;
-use std::path;
-use std::io::BufWriter;
 use std::fs::File;
-use pdf_extract::*;
-use lopdf::*;
+use std::io::BufWriter;
+use std::path;
+use std::path::PathBuf;
 
 fn main() {
     //let output_kind = "html";
@@ -15,28 +15,30 @@ fn main() {
     //let output_kind = "svg";
     let file = env::args().nth(1).unwrap();
     let output_kind = env::args().nth(2).unwrap_or_else(|| "txt".to_owned());
-    println!("{}", file);
+    println!("{file}");
     let path = path::Path::new(&file);
     let filename = path.file_name().expect("expected a filename");
     let mut output_file = PathBuf::new();
     output_file.push(filename);
     output_file.set_extension(&output_kind);
-    let mut output_file = BufWriter::new(File::create(output_file).expect("could not create output"));
+    let mut output_file =
+        BufWriter::new(File::create(output_file).expect("could not create output"));
     let mut doc = Document::load(path).unwrap();
-
 
     print_metadata(&doc);
 
     let mut output: Box<dyn OutputDev> = match output_kind.as_ref() {
-        "txt" => Box::new(PlainTextOutput::new(&mut output_file as &mut dyn std::io::Write)),
+        "txt" => Box::new(PlainTextOutput::new(
+            &mut output_file as &mut dyn std::io::Write,
+        )),
         "html" => Box::new(HTMLOutput::new(&mut output_file)),
         "svg" => Box::new(SVGOutput::new(&mut output_file)),
         _ => panic!(),
     };
 
     if doc.is_encrypted() {
-        doc.decrypt("");
+        let _ = doc.decrypt("");
     }
 
-    output_doc(&doc, output.as_mut());
+    let _ = output_doc(&doc, output.as_mut());
 }

--- a/src/glyphnames.rs
+++ b/src/glyphnames.rs
@@ -4706,6 +4706,6 @@ pub fn name_to_unicode(name: &str) -> Option<u16> {
 ("zuhiragana", 0x305a),
 ("zukatakana", 0x30ba)
     ];
-    let result = names.binary_search_by_key(&name, |&(name,_code)| &name);
+    let result = names.binary_search_by_key(&name, |&(name,_code)| name);
     result.ok().map(|indx| names[indx].1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,7 +583,7 @@ impl<'a> PdfSimpleFont<'a> {
                                 code += 1;
                             }
                             _ => {
-                                panic!("wrong type {:?}", o);
+                                panic!("wrong type {o:?}");
                             }
                         }
                     }
@@ -705,7 +705,7 @@ impl<'a> PdfSimpleFont<'a> {
                             if w.0 != -1 {
                                 table[w.0 as usize] = if base_name == "ZapfDingbats" {
                                     zapfglyphnames::zapfdigbats_names_to_unicode(w.2)
-                                        .unwrap_or_else(|| panic!("bad name {:?}", w))
+                                        .unwrap_or_else(|| panic!("bad name {w:?}"))
                                 } else {
                                     glyphnames::name_to_unicode(w.2).unwrap()
                                 }
@@ -960,7 +960,7 @@ impl PdfFont for PdfSimpleFont<'_> {
                     println!("falling back to encoding {char} -> {s:?}");
                     s
                 },
-                |s| s.clone(),
+                std::clone::Clone::clone,
             );
             return s;
         }
@@ -1016,7 +1016,7 @@ impl PdfFont for PdfType3Font<'_> {
                     println!("falling back to encoding {char} -> {s:?}");
                     s
                 },
-                |s| s.clone(),
+                std::clone::Clone::clone,
             );
 
             return s;
@@ -1088,7 +1088,7 @@ fn get_unicode_map<'a>(doc: &'a Document, font: &'a Dictionary) -> Option<HashMa
             }
         }
         _ => {
-            panic!("unsupported cmap {:?}", to_unicode)
+            panic!("unsupported cmap {to_unicode:?}")
         }
     }
     unicode_map
@@ -1124,7 +1124,7 @@ impl<'a> PdfCIDFont<'a> {
                         }],
                     }
                 } else {
-                    panic!("unsupported encoding {}", name);
+                    panic!("unsupported encoding {name}");
                 }
             }
             Object::Stream(stream) => {
@@ -1133,7 +1133,7 @@ impl<'a> PdfCIDFont<'a> {
                 adobe_cmap_parser::get_byte_mapping(&contents).unwrap()
             }
             _ => {
-                panic!("unsupported encoding {:?}", encoding)
+                panic!("unsupported encoding {encoding:?}")
             }
         };
 
@@ -1330,10 +1330,7 @@ impl Function {
 
         match function_type {
             0 => {
-                let stream = match obj {
-                    Object::Stream(stream) => stream,
-                    _ => panic!(),
-                };
+                let stream = if let Object::Stream(stream) = obj { stream } else { panic!() };
                 let range: Vec<f64> = get(doc, dict, b"Range");
                 let domain: Vec<f64> = get(doc, dict, b"Domain");
                 let contents = get_contents(stream);
@@ -1370,7 +1367,7 @@ impl Function {
                 Self::Type2(Type2Func { c0, c1, n })
             }
             _ => {
-                panic!("unhandled function type {}", function_type)
+                panic!("unhandled function type {function_type}")
             }
         }
     }
@@ -1505,7 +1502,7 @@ fn apply_state(doc: &Document, gs: &mut GraphicsState, state: &Dictionary) {
                     gs.smask = Some(dict.clone());
                 }
                 _ => {
-                    panic!("unexpected smask type {:?}", v)
+                    panic!("unexpected smask type {v:?}")
                 }
             },
             b"Type" => match v {
@@ -1617,7 +1614,7 @@ fn make_colorspace<'a>(doc: &'a Document, name: &[u8], resources: &'a Dictionary
         _ => {
             let colorspaces: &Dictionary = get(doc, resources, b"ColorSpace");
             let cs: &Object = maybe_get_obj(doc, colorspaces, name)
-                .unwrap_or_else(|| panic!("missing colorspace {:?}", name));
+                .unwrap_or_else(|| panic!("missing colorspace {name:?}"));
 
             cs.as_array().map_or_else(
                 |_| {
@@ -1737,7 +1734,7 @@ fn make_colorspace<'a>(doc: &'a Document, name: &[u8], resources: &'a Dictionary
                         "DeviceCMYK" => ColorSpace::DeviceCMYK,
                         "DeviceN" => ColorSpace::DeviceN,
                         _ => {
-                            panic!("color_space {:?} {:?} {:?}", name, cs_name, cs)
+                            panic!("color_space {name:?} {cs_name:?} {cs:?}")
                         }
                     }
                 },
@@ -1886,7 +1883,7 @@ impl<'a> Processor<'a> {
                         show_text(&mut gs, s, &tlm, &flip_ctm, output)?;
                     }
                     _ => {
-                        panic!("unexpected Tj operand {:?}", operation)
+                        panic!("unexpected Tj operand {operation:?}")
                     }
                 },
                 "Tc" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,72 +1,73 @@
-extern crate lopdf;
+#![allow(clippy::literal_string_with_formatting_args)]
+#![allow(dead_code)]
 
-use adobe_cmap_parser::{ByteMapping, CodeRange, CIDRange};
-use encoding_rs::UTF_16BE;
-use lopdf::content::Content;
-pub use lopdf::*;
-use euclid::*;
-use lopdf::encryption::DecryptionError;
-use std::fmt::{Debug, Formatter};
+extern crate adobe_cmap_parser;
 extern crate encoding_rs;
 extern crate euclid;
-extern crate adobe_cmap_parser;
+extern crate lopdf;
 extern crate type1_encoding_parser;
 extern crate unicode_normalization;
+
+use adobe_cmap_parser::{ByteMapping, CIDRange, CodeRange};
+use encoding_rs::UTF_16BE;
 use euclid::vec2;
-use unicode_normalization::UnicodeNormalization;
-use std::fmt;
-use std::str;
-use std::fs::File;
-use std::slice::Iter;
-use std::collections::HashMap;
+use euclid::Transform2D;
+use lopdf::{content::Content, encryption::DecryptionError};
+pub use lopdf::{Dictionary, Document, Error, Object, ObjectId, Stream, StringFormat};
 use std::collections::hash_map::Entry;
-use std::rc::Rc;
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Write;
+use std::fmt::{Debug, Formatter};
+use std::fs::File;
 use std::marker::PhantomData;
+use std::rc::Rc;
 use std::result::Result;
+use std::slice::Iter;
+use unicode_normalization::UnicodeNormalization;
+
 mod core_fonts;
+mod encodings;
 mod glyphnames;
 mod zapfglyphnames;
-mod encodings;
 
 pub struct Space;
 pub type Transform = Transform2D<f64, Space, Space>;
 
 #[derive(Debug)]
-pub enum OutputError
-{
+pub enum OutputError {
     FormatError(std::fmt::Error),
     IoError(std::io::Error),
-    PdfError(lopdf::Error)
+    PdfError(lopdf::Error),
 }
 
-impl std::fmt::Display for OutputError
-{
+impl std::fmt::Display for OutputError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            OutputError::FormatError(e) => write!(f, "Formating error: {}", e),
-            OutputError::IoError(e) => write!(f, "IO error: {}", e),
-            OutputError::PdfError(e) => write!(f, "PDF error: {}", e)
+            Self::FormatError(e) => write!(f, "Formating error: {e}"),
+            Self::IoError(e) => write!(f, "IO error: {e}"),
+            Self::PdfError(e) => write!(f, "PDF error: {e}"),
         }
     }
 }
 
-impl std::error::Error for OutputError{}
+impl std::error::Error for OutputError {}
 
 impl From<std::fmt::Error> for OutputError {
     fn from(e: std::fmt::Error) -> Self {
-        OutputError::FormatError(e)
+        Self::FormatError(e)
     }
 }
 
 impl From<std::io::Error> for OutputError {
     fn from(e: std::io::Error) -> Self {
-        OutputError::IoError(e)
+        Self::IoError(e)
     }
 }
 
 impl From<lopdf::Error> for OutputError {
     fn from(e: lopdf::Error) -> Self {
-        OutputError::PdfError(e)
+        Self::PdfError(e)
     }
 }
 
@@ -76,27 +77,19 @@ macro_rules! dlog {
 }
 
 fn get_info(doc: &Document) -> Option<&Dictionary> {
-    match doc.trailer.get(b"Info") {
-        Ok(&Object::Reference(ref id)) => {
-            match doc.get_object(*id) {
-                Ok(&Object::Dictionary(ref info)) => { return Some(info); }
-                _ => {}
-            }
+    if let Ok(Object::Reference(id)) = doc.trailer.get(b"Info") {
+        if let Ok(Object::Dictionary(info)) = doc.get_object(*id) {
+            return Some(info);
         }
-        _ => {}
     }
     None
 }
 
 fn get_catalog(doc: &Document) -> &Dictionary {
-    match doc.trailer.get(b"Root").unwrap() {
-        &Object::Reference(ref id) => {
-            match doc.get_object(*id) {
-                Ok(&Object::Dictionary(ref catalog)) => { return catalog; }
-                _ => {}
-            }
+    if let Object::Reference(id) = doc.trailer.get(b"Root").unwrap() {
+        if let Ok(Object::Dictionary(catalog)) = doc.get_object(*id) {
+            return catalog;
         }
-        _ => {}
     }
     panic!();
 }
@@ -104,77 +97,96 @@ fn get_catalog(doc: &Document) -> &Dictionary {
 fn get_pages(doc: &Document) -> &Dictionary {
     let catalog = get_catalog(doc);
     match catalog.get(b"Pages").unwrap() {
-        &Object::Reference(ref id) => {
-            match doc.get_object(*id) {
-                Ok(&Object::Dictionary(ref pages)) => { return pages; }
-                other => {dlog!("pages: {:?}", other)}
+        Object::Reference(id) => match doc.get_object(*id) {
+            Ok(Object::Dictionary(pages)) => {
+                return pages;
             }
+            other => {
+                dlog!("pages: {:?}", other);
+            }
+        },
+        other => {
+            dlog!("pages: {:?}", other);
         }
-        other => { dlog!("pages: {:?}", other)}
     }
     dlog!("catalog {:?}", catalog);
     panic!();
 }
 
 #[allow(non_upper_case_globals)]
-const PDFDocEncoding: &'static [u16] = &[
-    0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008,
-    0x0009, 0x000a, 0x000b, 0x000c, 0x000d, 0x000e, 0x000f, 0x0010, 0x0011,
-    0x0012, 0x0013, 0x0014, 0x0015, 0x0016, 0x0017, 0x02d8, 0x02c7, 0x02c6,
-    0x02d9, 0x02dd, 0x02db, 0x02da, 0x02dc, 0x0020, 0x0021, 0x0022, 0x0023,
-    0x0024, 0x0025, 0x0026, 0x0027, 0x0028, 0x0029, 0x002a, 0x002b, 0x002c,
-    0x002d, 0x002e, 0x002f, 0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035,
-    0x0036, 0x0037, 0x0038, 0x0039, 0x003a, 0x003b, 0x003c, 0x003d, 0x003e,
-    0x003f, 0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047,
-    0x0048, 0x0049, 0x004a, 0x004b, 0x004c, 0x004d, 0x004e, 0x004f, 0x0050,
-    0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057, 0x0058, 0x0059,
-    0x005a, 0x005b, 0x005c, 0x005d, 0x005e, 0x005f, 0x0060, 0x0061, 0x0062,
-    0x0063, 0x0064, 0x0065, 0x0066, 0x0067, 0x0068, 0x0069, 0x006a, 0x006b,
-    0x006c, 0x006d, 0x006e, 0x006f, 0x0070, 0x0071, 0x0072, 0x0073, 0x0074,
-    0x0075, 0x0076, 0x0077, 0x0078, 0x0079, 0x007a, 0x007b, 0x007c, 0x007d,
-    0x007e, 0x0000, 0x2022, 0x2020, 0x2021, 0x2026, 0x2014, 0x2013, 0x0192,
-    0x2044, 0x2039, 0x203a, 0x2212, 0x2030, 0x201e, 0x201c, 0x201d, 0x2018,
-    0x2019, 0x201a, 0x2122, 0xfb01, 0xfb02, 0x0141, 0x0152, 0x0160, 0x0178,
-    0x017d, 0x0131, 0x0142, 0x0153, 0x0161, 0x017e, 0x0000, 0x20ac, 0x00a1,
-    0x00a2, 0x00a3, 0x00a4, 0x00a5, 0x00a6, 0x00a7, 0x00a8, 0x00a9, 0x00aa,
-    0x00ab, 0x00ac, 0x0000, 0x00ae, 0x00af, 0x00b0, 0x00b1, 0x00b2, 0x00b3,
-    0x00b4, 0x00b5, 0x00b6, 0x00b7, 0x00b8, 0x00b9, 0x00ba, 0x00bb, 0x00bc,
-    0x00bd, 0x00be, 0x00bf, 0x00c0, 0x00c1, 0x00c2, 0x00c3, 0x00c4, 0x00c5,
-    0x00c6, 0x00c7, 0x00c8, 0x00c9, 0x00ca, 0x00cb, 0x00cc, 0x00cd, 0x00ce,
-    0x00cf, 0x00d0, 0x00d1, 0x00d2, 0x00d3, 0x00d4, 0x00d5, 0x00d6, 0x00d7,
-    0x00d8, 0x00d9, 0x00da, 0x00db, 0x00dc, 0x00dd, 0x00de, 0x00df, 0x00e0,
-    0x00e1, 0x00e2, 0x00e3, 0x00e4, 0x00e5, 0x00e6, 0x00e7, 0x00e8, 0x00e9,
-    0x00ea, 0x00eb, 0x00ec, 0x00ed, 0x00ee, 0x00ef, 0x00f0, 0x00f1, 0x00f2,
-    0x00f3, 0x00f4, 0x00f5, 0x00f6, 0x00f7, 0x00f8, 0x00f9, 0x00fa, 0x00fb,
-    0x00fc, 0x00fd, 0x00fe, 0x00ff];
+const PDFDocEncoding: &[u16] = &[
+    0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009, 0x000a, 0x000b,
+    0x000c, 0x000d, 0x000e, 0x000f, 0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015, 0x0016, 0x0017,
+    0x02d8, 0x02c7, 0x02c6, 0x02d9, 0x02dd, 0x02db, 0x02da, 0x02dc, 0x0020, 0x0021, 0x0022, 0x0023,
+    0x0024, 0x0025, 0x0026, 0x0027, 0x0028, 0x0029, 0x002a, 0x002b, 0x002c, 0x002d, 0x002e, 0x002f,
+    0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037, 0x0038, 0x0039, 0x003a, 0x003b,
+    0x003c, 0x003d, 0x003e, 0x003f, 0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047,
+    0x0048, 0x0049, 0x004a, 0x004b, 0x004c, 0x004d, 0x004e, 0x004f, 0x0050, 0x0051, 0x0052, 0x0053,
+    0x0054, 0x0055, 0x0056, 0x0057, 0x0058, 0x0059, 0x005a, 0x005b, 0x005c, 0x005d, 0x005e, 0x005f,
+    0x0060, 0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067, 0x0068, 0x0069, 0x006a, 0x006b,
+    0x006c, 0x006d, 0x006e, 0x006f, 0x0070, 0x0071, 0x0072, 0x0073, 0x0074, 0x0075, 0x0076, 0x0077,
+    0x0078, 0x0079, 0x007a, 0x007b, 0x007c, 0x007d, 0x007e, 0x0000, 0x2022, 0x2020, 0x2021, 0x2026,
+    0x2014, 0x2013, 0x0192, 0x2044, 0x2039, 0x203a, 0x2212, 0x2030, 0x201e, 0x201c, 0x201d, 0x2018,
+    0x2019, 0x201a, 0x2122, 0xfb01, 0xfb02, 0x0141, 0x0152, 0x0160, 0x0178, 0x017d, 0x0131, 0x0142,
+    0x0153, 0x0161, 0x017e, 0x0000, 0x20ac, 0x00a1, 0x00a2, 0x00a3, 0x00a4, 0x00a5, 0x00a6, 0x00a7,
+    0x00a8, 0x00a9, 0x00aa, 0x00ab, 0x00ac, 0x0000, 0x00ae, 0x00af, 0x00b0, 0x00b1, 0x00b2, 0x00b3,
+    0x00b4, 0x00b5, 0x00b6, 0x00b7, 0x00b8, 0x00b9, 0x00ba, 0x00bb, 0x00bc, 0x00bd, 0x00be, 0x00bf,
+    0x00c0, 0x00c1, 0x00c2, 0x00c3, 0x00c4, 0x00c5, 0x00c6, 0x00c7, 0x00c8, 0x00c9, 0x00ca, 0x00cb,
+    0x00cc, 0x00cd, 0x00ce, 0x00cf, 0x00d0, 0x00d1, 0x00d2, 0x00d3, 0x00d4, 0x00d5, 0x00d6, 0x00d7,
+    0x00d8, 0x00d9, 0x00da, 0x00db, 0x00dc, 0x00dd, 0x00de, 0x00df, 0x00e0, 0x00e1, 0x00e2, 0x00e3,
+    0x00e4, 0x00e5, 0x00e6, 0x00e7, 0x00e8, 0x00e9, 0x00ea, 0x00eb, 0x00ec, 0x00ed, 0x00ee, 0x00ef,
+    0x00f0, 0x00f1, 0x00f2, 0x00f3, 0x00f4, 0x00f5, 0x00f6, 0x00f7, 0x00f8, 0x00f9, 0x00fa, 0x00fb,
+    0x00fc, 0x00fd, 0x00fe, 0x00ff,
+];
 
 fn pdf_to_utf8(s: &[u8]) -> String {
     if s.len() > 2 && s[0] == 0xfe && s[1] == 0xff {
-        return UTF_16BE.decode_without_bom_handling_and_without_replacement(&s[2..]).unwrap().to_string()
+        UTF_16BE
+            .decode_without_bom_handling_and_without_replacement(&s[2..])
+            .unwrap()
+            .to_string()
     } else {
-        let r : Vec<u8> = s.iter().map(|x| *x).flat_map(|x| {
-               let k = PDFDocEncoding[x as usize];
-               vec![(k>>8) as u8, k as u8].into_iter()}).collect();
-        return UTF_16BE.decode_without_bom_handling_and_without_replacement(&r).unwrap().to_string()
+        let r: Vec<u8> = s
+            .iter()
+            .copied()
+            .flat_map(|x| {
+                let k = PDFDocEncoding[x as usize];
+                vec![(k >> 8) as u8, k as u8].into_iter()
+            })
+            .collect();
+        UTF_16BE
+            .decode_without_bom_handling_and_without_replacement(&r)
+            .unwrap()
+            .to_string()
     }
 }
 
 fn to_utf8(encoding: &[u16], s: &[u8]) -> String {
     if s.len() > 2 && s[0] == 0xfe && s[1] == 0xff {
-        return UTF_16BE.decode_without_bom_handling_and_without_replacement(&s[2..]).unwrap().to_string()
+        UTF_16BE
+            .decode_without_bom_handling_and_without_replacement(&s[2..])
+            .unwrap()
+            .to_string()
     } else {
-        let r : Vec<u8> = s.iter().map(|x| *x).flat_map(|x| {
-            let k = encoding[x as usize];
-            vec![(k>>8) as u8, k as u8].into_iter()}).collect();
-        return UTF_16BE.decode_without_bom_handling_and_without_replacement(&r).unwrap().to_string()
+        let r: Vec<u8> = s
+            .iter()
+            .copied()
+            .flat_map(|x| {
+                let k = encoding[x as usize];
+                vec![(k >> 8) as u8, k as u8].into_iter()
+            })
+            .collect();
+        UTF_16BE
+            .decode_without_bom_handling_and_without_replacement(&r)
+            .unwrap()
+            .to_string()
     }
 }
-
 
 fn maybe_deref<'a>(doc: &'a Document, o: &'a Object) -> &'a Object {
     match o {
         &Object::Reference(r) => doc.get_object(r).expect("missing object reference"),
-        _ => o
+        _ => o,
     }
 }
 
@@ -188,19 +200,26 @@ trait FromOptObj<'a> {
 }
 
 // conditionally convert to Self returns None if the conversion failed
-trait FromObj<'a> where Self: std::marker::Sized {
+trait FromObj<'a>
+where
+    Self: std::marker::Sized,
+{
     fn from_obj(doc: &'a Document, obj: &'a Object) -> Option<Self>;
 }
 
 impl<'a, T: FromObj<'a>> FromOptObj<'a> for Option<T> {
     fn from_opt_obj(doc: &'a Document, obj: Option<&'a Object>, _key: &[u8]) -> Self {
-        obj.and_then(|x| T::from_obj(doc,x))
+        obj.and_then(|x| T::from_obj(doc, x))
     }
 }
 
 impl<'a, T: FromObj<'a>> FromOptObj<'a> for T {
     fn from_opt_obj(doc: &'a Document, obj: Option<&'a Object>, key: &[u8]) -> Self {
-        T::from_obj(doc, obj.expect(&String::from_utf8_lossy(key))).expect("wrong type")
+        T::from_obj(
+            doc,
+            obj.unwrap_or_else(|| panic!("{}", String::from_utf8_lossy(key).to_string())),
+        )
+        .expect("wrong type")
     }
 }
 
@@ -208,9 +227,14 @@ impl<'a, T: FromObj<'a>> FromOptObj<'a> for T {
 // on arrays, streams and dicts
 impl<'a, T: FromObj<'a>> FromObj<'a> for Vec<T> {
     fn from_obj(doc: &'a Document, obj: &'a Object) -> Option<Self> {
-        maybe_deref(doc, obj).as_array().map(|x| x.iter()
-            .map(|x| T::from_obj(doc, x).expect("wrong type"))
-            .collect()).ok()
+        maybe_deref(doc, obj)
+            .as_array()
+            .map(|x| {
+                x.iter()
+                    .map(|x| T::from_obj(doc, x).expect("wrong type"))
+                    .collect()
+            })
+            .ok()
     }
 }
 
@@ -218,39 +242,52 @@ impl<'a, T: FromObj<'a>> FromObj<'a> for Vec<T> {
 // we don't want to do that
 impl<'a, T: FromObj<'a>> FromObj<'a> for [T; 4] {
     fn from_obj(doc: &'a Document, obj: &'a Object) -> Option<Self> {
-        maybe_deref(doc, obj).as_array().map(|x| {
-            let mut all = x.iter()
-                .map(|x| T::from_obj(doc, x).expect("wrong type"));
-            [all.next().unwrap(), all.next().unwrap(), all.next().unwrap(), all.next().unwrap()]
-        }).ok()
+        maybe_deref(doc, obj)
+            .as_array()
+            .map(|x| {
+                let mut all = x.iter().map(|x| T::from_obj(doc, x).expect("wrong type"));
+                [
+                    all.next().unwrap(),
+                    all.next().unwrap(),
+                    all.next().unwrap(),
+                    all.next().unwrap(),
+                ]
+            })
+            .ok()
     }
 }
 
 impl<'a, T: FromObj<'a>> FromObj<'a> for [T; 3] {
     fn from_obj(doc: &'a Document, obj: &'a Object) -> Option<Self> {
-        maybe_deref(doc, obj).as_array().map(|x| {
-            let mut all = x.iter()
-                .map(|x| T::from_obj(doc, x).expect("wrong type"));
-            [all.next().unwrap(), all.next().unwrap(), all.next().unwrap()]
-        }).ok()
+        maybe_deref(doc, obj)
+            .as_array()
+            .map(|x| {
+                let mut all = x.iter().map(|x| T::from_obj(doc, x).expect("wrong type"));
+                [
+                    all.next().unwrap(),
+                    all.next().unwrap(),
+                    all.next().unwrap(),
+                ]
+            })
+            .ok()
     }
 }
 
-impl<'a> FromObj<'a> for f64 {
+impl FromObj<'_> for f64 {
     fn from_obj(_doc: &Document, obj: &Object) -> Option<Self> {
-        match obj {
-            &Object::Integer(i) => Some(i as f64),
-            &Object::Real(f) => Some(f.into()),
-            _ => None
+        match *obj {
+            Object::Integer(i) => Some(i as Self),
+            Object::Real(f) => Some(f.into()),
+            _ => None,
         }
     }
 }
 
-impl<'a> FromObj<'a> for i64 {
+impl FromObj<'_> for i64 {
     fn from_obj(_doc: &Document, obj: &Object) -> Option<Self> {
         match obj {
             &Object::Integer(i) => Some(i),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -282,19 +319,34 @@ fn maybe_get<'a, T: FromObj<'a>>(doc: &'a Document, dict: &'a Dictionary, key: &
 }
 
 fn get_name_string<'a>(doc: &'a Document, dict: &'a Dictionary, key: &[u8]) -> String {
-    pdf_to_utf8(dict.get(key).map(|o| maybe_deref(doc, o)).unwrap_or_else(|_| panic!("deref")).as_name().expect("name"))
+    pdf_to_utf8(
+        dict.get(key)
+            .map_or_else(|_| panic!("deref"), |o| maybe_deref(doc, o))
+            .as_name()
+            .expect("name"),
+    )
 }
 
 #[allow(dead_code)]
-fn maybe_get_name_string<'a>(doc: &'a Document, dict: &'a Dictionary, key: &[u8]) -> Option<String> {
-    maybe_get_obj(doc, dict, key).and_then(|n| n.as_name().ok()).map(|n| pdf_to_utf8(n))
+fn maybe_get_name_string<'a>(
+    doc: &'a Document,
+    dict: &'a Dictionary,
+    key: &[u8],
+) -> Option<String> {
+    maybe_get_obj(doc, dict, key)
+        .and_then(|n| n.as_name().ok())
+        .map(pdf_to_utf8)
 }
 
 fn maybe_get_name<'a>(doc: &'a Document, dict: &'a Dictionary, key: &[u8]) -> Option<&'a [u8]> {
     maybe_get_obj(doc, dict, key).and_then(|n| n.as_name().ok())
 }
 
-fn maybe_get_array<'a>(doc: &'a Document, dict: &'a Dictionary, key: &[u8]) -> Option<&'a Vec<Object>> {
+fn maybe_get_array<'a>(
+    doc: &'a Document,
+    dict: &'a Dictionary,
+    key: &[u8],
+) -> Option<&'a Vec<Object>> {
     maybe_get_obj(doc, dict, key).and_then(|n| n.as_array().ok())
 }
 
@@ -317,7 +369,6 @@ struct PdfType3Font<'a> {
     widths: HashMap<CharCode, f64>, // should probably just use i32 here
 }
 
-
 fn make_font<'a>(doc: &'a Document, font: &'a Dictionary) -> Rc<dyn PdfFont + 'a> {
     let subtype = get_name_string(doc, font, b"Subtype");
     dlog!("MakeFont({})", subtype);
@@ -331,34 +382,41 @@ fn make_font<'a>(doc: &'a Document, font: &'a Dictionary) -> Rc<dyn PdfFont + 'a
 }
 
 fn is_core_font(name: &str) -> bool {
-    match name {
-        "Courier-Bold" |
-        "Courier-BoldOblique" |
-        "Courier-Oblique" |
-        "Courier" |
-        "Helvetica-Bold" |
-        "Helvetica-BoldOblique" |
-        "Helvetica-Oblique" |
-        "Helvetica" |
-        "Symbol" |
-        "Times-Bold" |
-        "Times-BoldItalic" |
-        "Times-Italic" |
-        "Times-Roman" |
-        "ZapfDingbats" => true,
-        _ => false,
-    }
+    matches!(
+        name,
+        "Courier-Bold"
+            | "Courier-BoldOblique"
+            | "Courier-Oblique"
+            | "Courier"
+            | "Helvetica-Bold"
+            | "Helvetica-BoldOblique"
+            | "Helvetica-Oblique"
+            | "Helvetica"
+            | "Symbol"
+            | "Times-Bold"
+            | "Times-BoldItalic"
+            | "Times-Italic"
+            | "Times-Roman"
+            | "ZapfDingbats"
+    )
 }
 
 fn encoding_to_unicode_table(name: &[u8]) -> Vec<u16> {
-    let encoding = match &name[..] {
+    let encoding = match name {
         b"MacRomanEncoding" => encodings::MAC_ROMAN_ENCODING,
         b"MacExpertEncoding" => encodings::MAC_EXPERT_ENCODING,
         b"WinAnsiEncoding" => encodings::WIN_ANSI_ENCODING,
-        _ => panic!("unexpected encoding {:?}", pdf_to_utf8(name))
+        _ => panic!("unexpected encoding {:?}", pdf_to_utf8(name)),
     };
-    let encoding_table = encoding.iter()
-        .map(|x| if let &Some(x) = x { glyphnames::name_to_unicode(x).unwrap() } else { 0 })
+    let encoding_table = encoding
+        .iter()
+        .map(|x| {
+            if let &Some(x) = x {
+                glyphnames::name_to_unicode(x).unwrap()
+            } else {
+                0
+            }
+        })
         .collect();
     encoding_table
 }
@@ -370,12 +428,18 @@ fn encoding_to_unicode_table(name: &[u8]) -> Vec<u16> {
     described in Section 5.5.5, “Character Encoding.”
 */
 impl<'a> PdfSimpleFont<'a> {
-    fn new(doc: &'a Document, font: &'a Dictionary) -> PdfSimpleFont<'a> {
+    fn new(doc: &'a Document, font: &'a Dictionary) -> Self {
         let base_name = get_name_string(doc, font, b"BaseFont");
         let subtype = get_name_string(doc, font, b"Subtype");
 
         let encoding: Option<&Object> = get(doc, font, b"Encoding");
-        dlog!("base_name {} {} enc:{:?} {:?}", base_name, subtype, encoding, font);
+        dlog!(
+            "base_name {} {} enc:{:?} {:?}",
+            base_name,
+            subtype,
+            encoding,
+            font
+        );
         let descriptor: Option<&Dictionary> = get(doc, font, b"FontDescriptor");
         let mut type1_encoding = None;
         if let Some(descriptor) = descriptor {
@@ -383,38 +447,45 @@ impl<'a> PdfSimpleFont<'a> {
             if subtype == "Type1" {
                 let file = maybe_get_obj(doc, descriptor, b"FontFile");
                 match file {
-                    Some(&Object::Stream(ref s)) => {
+                    Some(Object::Stream(s)) => {
                         let s = get_contents(s);
                         //dlog!("font contents {:?}", pdf_to_utf8(&s));
-                        type1_encoding = Some(type1_encoding_parser::get_encoding_map(&s).expect("encoding"));
+                        type1_encoding =
+                            Some(type1_encoding_parser::get_encoding_map(&s).expect("encoding"));
                     }
-                    _ => { dlog!("font file {:?}", file) }
+                    _ => {
+                        dlog!("font file {:?}", file);
+                    }
                 }
             } else if subtype == "TrueType" {
                 let file = maybe_get_obj(doc, descriptor, b"FontFile2");
                 match file {
-                    Some(&Object::Stream(ref s)) => {
+                    Some(Object::Stream(s)) => {
                         let _s = get_contents(s);
                         //File::create(format!("/tmp/{}", base_name)).unwrap().write_all(&s);
                     }
-                    _ => { dlog!("font file {:?}", file) }
+                    _ => {
+                        dlog!("font file {:?}", file);
+                    }
                 }
             }
 
             let font_file3 = get::<Option<&Object>>(doc, descriptor, b"FontFile3");
             match font_file3 {
-                Some(&Object::Stream(ref s)) => {
+                Some(Object::Stream(s)) => {
                     let subtype = get_name_string(doc, &s.dict, b"Subtype");
                     dlog!("font file {}, {:?}", subtype, s);
                 }
                 None => {}
-                _ => { dlog!("unexpected") }
+                _ => {
+                    dlog!("unexpected");
+                }
             }
 
             let charset = maybe_get_obj(doc, descriptor, b"CharSet");
             let _charset = match charset {
-                Some(&Object::String(ref s, _)) => { Some(pdf_to_utf8(&s)) }
-                _ => { None }
+                Some(Object::String(s, _)) => Some(pdf_to_utf8(s)),
+                _ => None,
             };
             //dlog!("charset {:?}", charset);
         }
@@ -423,18 +494,19 @@ impl<'a> PdfSimpleFont<'a> {
 
         let mut encoding_table = None;
         match encoding {
-            Some(&Object::Name(ref encoding_name)) => {
+            Some(Object::Name(encoding_name)) => {
                 dlog!("encoding {:?}", pdf_to_utf8(encoding_name));
                 encoding_table = Some(encoding_to_unicode_table(encoding_name));
             }
-            Some(&Object::Dictionary(ref encoding)) => {
+            Some(Object::Dictionary(encoding)) => {
                 //dlog!("Encoding {:?}", encoding);
-                let mut table = if let Some(base_encoding) = maybe_get_name(doc, encoding, b"BaseEncoding") {
-                    dlog!("BaseEncoding {:?}", base_encoding);
-                    encoding_to_unicode_table(base_encoding)
-                } else {
-                    Vec::from(PDFDocEncoding)
-                };
+                let mut table = maybe_get_name(doc, encoding, b"BaseEncoding").map_or_else(
+                    || Vec::from(PDFDocEncoding),
+                    |base_encoding| {
+                        dlog!("BaseEncoding {:?}", base_encoding);
+                        encoding_to_unicode_table(base_encoding)
+                    },
+                );
                 let differences = maybe_get_array(doc, encoding, b"Differences");
                 if let Some(differences) = differences {
                     dlog!("Differences");
@@ -442,41 +514,61 @@ impl<'a> PdfSimpleFont<'a> {
                     for o in differences {
                         let o = maybe_deref(doc, o);
                         match o {
-                            &Object::Integer(i) => { code = i; },
-                            &Object::Name(ref n) => {
-                                let name = pdf_to_utf8(&n);
+                            Object::Integer(i) => {
+                                code = *i;
+                            }
+                            Object::Name(ref n) => {
+                                let name = pdf_to_utf8(n);
                                 // XXX: names of Type1 fonts can map to arbitrary strings instead of real
                                 // unicode names, so we should probably handle this differently
                                 let unicode = glyphnames::name_to_unicode(&name);
-                                if let Some(unicode) = unicode{
+                                if let Some(unicode) = unicode {
                                     table[code as usize] = unicode;
                                     if let Some(ref mut unicode_map) = unicode_map {
                                         let be = [unicode];
                                         match unicode_map.entry(code as u32) {
                                             // If there's a unicode table entry missing use one based on the name
-                                            Entry::Vacant(v) => { v.insert(String::from_utf16(&be).unwrap()); }
+                                            Entry::Vacant(v) => {
+                                                v.insert(String::from_utf16(&be).unwrap());
+                                            }
                                             Entry::Occupied(e) => {
                                                 if e.get() != &String::from_utf16(&be).unwrap() {
-                                                    let normal_match  = e.get().nfkc().eq(String::from_utf16(&be).unwrap().nfkc());
-                                                    println!("Unicode mismatch {} {} {:?} {:?} {:?}", normal_match, name, e.get(), String::from_utf16(&be), be);
+                                                    let normal_match =
+                                                        e.get().nfkc().eq(String::from_utf16(&be)
+                                                            .unwrap()
+                                                            .nfkc());
+                                                    println!(
+                                                        "Unicode mismatch {} {} {:?} {:?} {:?}",
+                                                        normal_match,
+                                                        name,
+                                                        e.get(),
+                                                        String::from_utf16(&be),
+                                                        be
+                                                    );
                                                 }
                                             }
                                         }
                                     }
                                 } else {
                                     match unicode_map {
-                                        Some(ref mut unicode_map) if base_name.contains("FontAwesome") => {
+                                        Some(ref mut unicode_map)
+                                            if base_name.contains("FontAwesome") =>
+                                        {
                                             // the fontawesome tex package will use glyph names that don't have a corresponding unicode
                                             // code point, so we'll use an empty string instead. See issue #76
                                             match unicode_map.entry(code as u32) {
-                                                Entry::Vacant(v) => { v.insert("".to_owned()); }
-                                                Entry::Occupied(e) => {
+                                                Entry::Vacant(v) => {
+                                                    v.insert(String::new());
+                                                }
+                                                Entry::Occupied(_) => {
                                                     panic!("unexpected entry in unicode map")
                                                 }
                                             }
                                         }
                                         _ => {
-                                            println!("unknown glyph name '{}' for font {}", name, base_name);
+                                            println!(
+                                                "unknown glyph name '{name}' for font {base_name}"
+                                            );
                                         }
                                     }
                                 }
@@ -490,12 +582,17 @@ impl<'a> PdfSimpleFont<'a> {
                                 }
                                 code += 1;
                             }
-                            _ => { panic!("wrong type {:?}", o); }
+                            _ => {
+                                panic!("wrong type {:?}", o);
+                            }
                         }
                     }
                 }
                 // "Type" is optional
-                let name = encoding.get(b"Type").and_then(|x| x.as_name()).and_then(|x| Ok(pdf_to_utf8(x)));
+                let name = encoding
+                    .get(b"Type")
+                    .and_then(|x| x.as_name())
+                    .map(pdf_to_utf8);
                 dlog!("name: {}", name);
 
                 encoding_table = Some(table);
@@ -512,29 +609,50 @@ impl<'a> PdfSimpleFont<'a> {
                             dlog!("unknown character {}", pdf_to_utf8(&name));
                         }
                     }
-                    encoding_table = Some(table)
+                    encoding_table = Some(table);
                 } else if subtype == "TrueType" {
-                    encoding_table = Some(encodings::WIN_ANSI_ENCODING.iter()
-                        .map(|x| if let &Some(x) = x { glyphnames::name_to_unicode(x).unwrap() } else { 0 })
-                        .collect());
+                    encoding_table = Some(
+                        encodings::WIN_ANSI_ENCODING
+                            .iter()
+                            .map(|x| {
+                                if let &Some(x) = x {
+                                    glyphnames::name_to_unicode(x).unwrap()
+                                } else {
+                                    0
+                                }
+                            })
+                            .collect(),
+                    );
                 }
             }
-            _ => { panic!() }
+            _ => {
+                panic!();
+            }
         }
 
         let mut width_map = HashMap::new();
         /* "Ordinarily, a font dictionary that refers to one of the standard fonts
-            should omit the FirstChar, LastChar, Widths, and FontDescriptor entries.
-            However, it is permissible to override a standard font by including these
-            entries and embedding the font program in the PDF file."
+        should omit the FirstChar, LastChar, Widths, and FontDescriptor entries.
+        However, it is permissible to override a standard font by including these
+        entries and embedding the font program in the PDF file."
 
-            Note: some PDFs include a descriptor but still don't include these entries */
+        Note: some PDFs include a descriptor but still don't include these entries */
 
         // If we have widths prefer them over the core font widths. Needed for https://dkp.de/wp-content/uploads/parteitage/Sozialismusvorstellungen-der-DKP.pdf
-        if let (Some(first_char), Some(last_char), Some(widths)) = (maybe_get::<i64>(doc, font, b"FirstChar"), maybe_get::<i64>(doc, font, b"LastChar"), maybe_get::<Vec<f64>>(doc, font, b"Widths")) {
+        if let (Some(first_char), Some(last_char), Some(widths)) = (
+            maybe_get::<i64>(doc, font, b"FirstChar"),
+            maybe_get::<i64>(doc, font, b"LastChar"),
+            maybe_get::<Vec<f64>>(doc, font, b"Widths"),
+        ) {
             // Some PDF's don't have these like fips-197.pdf
             let mut i: i64 = 0;
-            dlog!("first_char {:?}, last_char: {:?}, widths: {} {:?}", first_char, last_char, widths.len(), widths);
+            dlog!(
+                "first_char {:?}, last_char: {:?}, widths: {} {:?}",
+                first_char,
+                last_char,
+                widths.len(),
+                widths
+            );
 
             for w in widths {
                 width_map.insert((first_char + i) as CharCode, w);
@@ -542,10 +660,10 @@ impl<'a> PdfSimpleFont<'a> {
             }
             assert_eq!(first_char + i - 1, last_char);
         } else {
-            let name = if is_core_font(&base_name) {
+            let _name = if is_core_font(&base_name) {
                 &base_name
             } else {
-                println!("no widths and not core font {:?}", base_name);
+                println!("no widths and not core font {base_name:?}");
 
                 // This situation is handled differently by different readers
                 // but basically we try to substitute the best font that we can.
@@ -563,17 +681,17 @@ impl<'a> PdfSimpleFont<'a> {
                 // or the basename but for now we'll just use Helvetica
                 "Helvetica"
             };
-            for font_metrics in core_fonts::metrics().iter() {
+            for font_metrics in &core_fonts::metrics() {
                 if font_metrics.0 == base_name {
                     if let Some(ref encoding) = encoding_table {
                         dlog!("has encoding");
                         for w in font_metrics.2 {
                             let c = glyphnames::name_to_unicode(w.2).unwrap();
-                            for i in 0..encoding.len() {
+                            (0..encoding.len()).for_each(|i| {
                                 if encoding[i] == c {
-                                    width_map.insert(i as CharCode, w.1 as f64);
+                                    width_map.insert(i as CharCode, w.1);
                                 }
-                            }
+                            });
                         }
                     } else {
                         // Instead of using the encoding from the core font we'll just look up all
@@ -586,7 +704,8 @@ impl<'a> PdfSimpleFont<'a> {
                             // -1 is "not encoded"
                             if w.0 != -1 {
                                 table[w.0 as usize] = if base_name == "ZapfDingbats" {
-                                    zapfglyphnames::zapfdigbats_names_to_unicode(w.2).unwrap_or_else(|| panic!("bad name {:?}", w))
+                                    zapfglyphnames::zapfdigbats_names_to_unicode(w.2)
+                                        .unwrap_or_else(|| panic!("bad name {:?}", w))
                                 } else {
                                     glyphnames::name_to_unicode(w.2).unwrap()
                                 }
@@ -595,17 +714,17 @@ impl<'a> PdfSimpleFont<'a> {
 
                         let encoding = &table[..];
                         for w in font_metrics.2 {
-                            width_map.insert(w.0 as CharCode, w.1 as f64);
+                            width_map.insert(w.0 as CharCode, w.1);
                             // -1 is "not encoded"
                         }
                         encoding_table = Some(encoding.to_vec());
                     }
                     /* "Ordinarily, a font dictionary that refers to one of the standard fonts
-                        should omit the FirstChar, LastChar, Widths, and FontDescriptor entries.
-                        However, it is permissible to override a standard font by including these
-                        entries and embedding the font program in the PDF file."
+                    should omit the FirstChar, LastChar, Widths, and FontDescriptor entries.
+                    However, it is permissible to override a standard font by including these
+                    entries and embedding the font program in the PDF file."
 
-                        Note: some PDFs include a descriptor but still don't include these entries */
+                    Note: some PDFs include a descriptor but still don't include these entries */
                     // assert!(maybe_get_obj(doc, font, b"FirstChar").is_none());
                     // assert!(maybe_get_obj(doc, font, b"LastChar").is_none());
                     // assert!(maybe_get_obj(doc, font, b"Widths").is_none());
@@ -614,7 +733,14 @@ impl<'a> PdfSimpleFont<'a> {
         }
 
         let missing_width = get::<Option<f64>>(doc, font, b"MissingWidth").unwrap_or(0.);
-        PdfSimpleFont {doc, font, widths: width_map, encoding: encoding_table, missing_width, unicode_map}
+        PdfSimpleFont {
+            doc,
+            font,
+            widths: width_map,
+            encoding: encoding_table,
+            missing_width,
+            unicode_map,
+        }
     }
 
     #[allow(dead_code)]
@@ -631,7 +757,8 @@ impl<'a> PdfSimpleFont<'a> {
     }
     #[allow(dead_code)]
     fn get_widths(&self) -> Option<&Vec<Object>> {
-        maybe_get_obj(self.doc, self.font, b"Widths").map(|widths| widths.as_array().expect("Widths should be an array"))
+        maybe_get_obj(self.doc, self.font, b"Widths")
+            .map(|widths| widths.as_array().expect("Widths should be an array"))
     }
     /* For type1: This entry is obsolescent and its use is no longer recommended. (See
      * implementation note 42 in Appendix H.) */
@@ -642,45 +769,50 @@ impl<'a> PdfSimpleFont<'a> {
 
     #[allow(dead_code)]
     fn get_descriptor(&self) -> Option<PdfFontDescriptor> {
-        maybe_get_obj(self.doc, self.font, b"FontDescriptor").and_then(|desc| desc.as_dict().ok()).map(|desc| PdfFontDescriptor{desc: desc, doc: self.doc})
+        maybe_get_obj(self.doc, self.font, b"FontDescriptor")
+            .and_then(|desc| desc.as_dict().ok())
+            .map(|desc| PdfFontDescriptor {
+                desc,
+                doc: self.doc,
+            })
     }
 }
 
-
-
 impl<'a> PdfType3Font<'a> {
-    fn new(doc: &'a Document, font: &'a Dictionary) -> PdfType3Font<'a> {
-
+    fn new(doc: &'a Document, font: &'a Dictionary) -> Self {
         let unicode_map = get_unicode_map(doc, font);
         let encoding: Option<&Object> = get(doc, font, b"Encoding");
 
         let encoding_table;
         match encoding {
-            Some(&Object::Name(ref encoding_name)) => {
+            Some(Object::Name(encoding_name)) => {
                 dlog!("encoding {:?}", pdf_to_utf8(encoding_name));
                 encoding_table = Some(encoding_to_unicode_table(encoding_name));
             }
-            Some(&Object::Dictionary(ref encoding)) => {
+            Some(Object::Dictionary(encoding)) => {
                 //dlog!("Encoding {:?}", encoding);
-                let mut table = if let Some(base_encoding) = maybe_get_name(doc, encoding, b"BaseEncoding") {
-                    dlog!("BaseEncoding {:?}", base_encoding);
-                    encoding_to_unicode_table(base_encoding)
-                } else {
-                    Vec::from(PDFDocEncoding)
-                };
+                let mut table = maybe_get_name(doc, encoding, b"BaseEncoding").map_or_else(
+                    || Vec::from(PDFDocEncoding),
+                    |base_encoding| {
+                        dlog!("BaseEncoding {:?}", base_encoding);
+                        encoding_to_unicode_table(base_encoding)
+                    },
+                );
                 let differences = maybe_get_array(doc, encoding, b"Differences");
                 if let Some(differences) = differences {
                     dlog!("Differences");
                     let mut code = 0;
                     for o in differences {
-                        match o {
-                            &Object::Integer(i) => { code = i; },
-                            &Object::Name(ref n) => {
-                                let name = pdf_to_utf8(&n);
+                        match *o {
+                            Object::Integer(i) => {
+                                code = i;
+                            }
+                            Object::Name(ref n) => {
+                                let name = pdf_to_utf8(n);
                                 // XXX: names of Type1 fonts can map to arbitrary strings instead of real
                                 // unicode names, so we should probably handle this differently
                                 let unicode = glyphnames::name_to_unicode(&name);
-                                if let Some(unicode) = unicode{
+                                if let Some(unicode) = unicode {
                                     table[code as usize] = unicode;
                                 }
                                 dlog!("{} = {} ({:?})", code, name, unicode);
@@ -689,7 +821,9 @@ impl<'a> PdfType3Font<'a> {
                                 }
                                 code += 1;
                             }
-                            _ => { panic!("wrong type"); }
+                            _ => {
+                                panic!("wrong type");
+                            }
                         }
                     }
                 }
@@ -702,7 +836,9 @@ impl<'a> PdfType3Font<'a> {
 
                 encoding_table = Some(table);
             }
-            _ => { panic!() }
+            _ => {
+                panic!();
+            }
         }
 
         let first_char: i64 = get(doc, font, b"FirstChar");
@@ -712,67 +848,88 @@ impl<'a> PdfType3Font<'a> {
         let mut width_map = HashMap::new();
 
         let mut i = 0;
-        dlog!("first_char {:?}, last_char: {:?}, widths: {} {:?}", first_char, last_char, widths.len(), widths);
+        dlog!(
+            "first_char {:?}, last_char: {:?}, widths: {} {:?}",
+            first_char,
+            last_char,
+            widths.len(),
+            widths
+        );
 
         for w in widths {
             width_map.insert((first_char + i) as CharCode, w);
             i += 1;
         }
         assert_eq!(first_char + i - 1, last_char);
-        PdfType3Font {doc, font, widths: width_map, encoding: encoding_table, unicode_map}
+        PdfType3Font {
+            doc,
+            font,
+            widths: width_map,
+            encoding: encoding_table,
+            unicode_map,
+        }
     }
 }
 
 type CharCode = u32;
 
-struct PdfFontIter<'a>
-{
+struct PdfFontIter<'a> {
     i: Iter<'a, u8>,
     font: &'a dyn PdfFont,
 }
 
-impl<'a> Iterator for PdfFontIter<'a> {
+impl Iterator for PdfFontIter<'_> {
     type Item = (CharCode, u8);
     fn next(&mut self) -> Option<(CharCode, u8)> {
         self.font.next_char(&mut self.i)
     }
 }
 
-trait PdfFont : Debug {
+trait PdfFont: Debug {
     fn get_width(&self, id: CharCode) -> f64;
     fn next_char(&self, iter: &mut Iter<u8>) -> Option<(CharCode, u8)>;
     fn decode_char(&self, char: CharCode) -> String;
 
-        /*fn char_codes<'a>(&'a self, chars: &'a [u8]) -> PdfFontIter {
-            let p = self;
-            PdfFontIter{i: chars.iter(), font: p as &PdfFont}
-        }*/
-
+    /*fn char_codes<'a>(&'a self, chars: &'a [u8]) -> PdfFontIter {
+        let p = self;
+        PdfFontIter{i: chars.iter(), font: p as &PdfFont}
+    }*/
 }
 
 impl<'a> dyn PdfFont + 'a {
-    fn char_codes(&'a self, chars: &'a [u8]) -> PdfFontIter {
-        PdfFontIter{i: chars.iter(), font: self}
+    fn char_codes(&'a self, chars: &'a [u8]) -> PdfFontIter<'a> {
+        PdfFontIter {
+            i: chars.iter(),
+            font: self,
+        }
     }
     fn decode(&self, chars: &[u8]) -> String {
-        let strings = self.char_codes(chars).map(|x| self.decode_char(x.0)).collect::<Vec<_>>();
+        let strings = self
+            .char_codes(chars)
+            .map(|x| self.decode_char(x.0))
+            .collect::<Vec<_>>();
         strings.join("")
     }
-
 }
 
-
-impl<'a> PdfFont for PdfSimpleFont<'a> {
+impl PdfFont for PdfSimpleFont<'_> {
     fn get_width(&self, id: CharCode) -> f64 {
         let width = self.widths.get(&id);
-        if let Some(width) = width {
-            return *width;
-        } else {
-            let mut widths = self.widths.iter().collect::<Vec<_>>();
-            widths.sort_by_key(|x| x.0);
-            dlog!("missing width for {} len(widths) = {}, {:?} falling back to missing_width {:?}", id, self.widths.len(), widths, self.font);
-            return self.missing_width;
-        }
+        width.map_or_else(
+            || {
+                let mut widths = self.widths.iter().collect::<Vec<_>>();
+                widths.sort_by_key(|x| x.0);
+                dlog!(
+                 "missing width for {} len(widths) = {}, {:?} falling back to missing_width {:?}",
+                 id,
+                 self.widths.len(),
+                 widths,
+                 self.font
+             );
+                self.missing_width
+            },
+            |width| *width,
+        )
     }
     /*fn decode(&self, chars: &[u8]) -> String {
         let encoding = self.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
@@ -780,49 +937,55 @@ impl<'a> PdfFont for PdfSimpleFont<'a> {
     }*/
 
     fn next_char(&self, iter: &mut Iter<u8>) -> Option<(CharCode, u8)> {
-        iter.next().map(|x| (*x as CharCode, 1))
+        iter.next().map(|x| (CharCode::from(*x), 1))
     }
     fn decode_char(&self, char: CharCode) -> String {
         let slice = [char as u8];
         if let Some(ref unicode_map) = self.unicode_map {
             let s = unicode_map.get(&char);
-            let s = match s {
-                None => {
-                    println!("missing char {:?} in unicode map {:?} for {:?}", char, unicode_map, self.font);
+            let s = s.map_or_else(
+                || {
+                    println!(
+                        "missing char {:?} in unicode map {:?} for {:?}",
+                        char, unicode_map, self.font
+                    );
                     // some pdf's like http://arxiv.org/pdf/2312.00064v1 are missing entries in their unicode map but do have
                     // entries in the encoding.
-                    let encoding = self.encoding.as_ref().map(|x| &x[..]).expect("missing unicode map and encoding");
+                    let encoding = self
+                        .encoding
+                        .as_ref()
+                        .map(|x| &x[..])
+                        .expect("missing unicode map and encoding");
                     let s = to_utf8(encoding, &slice);
-                    println!("falling back to encoding {} -> {:?}", char, s);
+                    println!("falling back to encoding {char} -> {s:?}");
                     s
-                }
-                Some(s) => { s.clone() }
-            };
-            return s
+                },
+                |s| s.clone(),
+            );
+            return s;
         }
-        let encoding = self.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
+        let encoding = self.encoding.as_ref().map_or(PDFDocEncoding, |x| &x[..]);
         //dlog!("char_code {:?} {:?}", char, self.encoding);
-        let s = to_utf8(encoding, &slice);
-        s
+
+        to_utf8(encoding, &slice)
     }
 }
 
-
-
-impl<'a> fmt::Debug for PdfSimpleFont<'a> {
+impl fmt::Debug for PdfSimpleFont<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.font.fmt(f)
     }
 }
 
-impl<'a> PdfFont for PdfType3Font<'a> {
+impl PdfFont for PdfType3Font<'_> {
     fn get_width(&self, id: CharCode) -> f64 {
         let width = self.widths.get(&id);
-        if let Some(width) = width {
-            return *width;
-        } else {
-            panic!("missing width for {} {:?}", id, self.font);
-        }
+        width.map_or_else(
+            || {
+                panic!("missing width for {} {:?}", id, self.font);
+            },
+            |width| *width,
+        )
     }
     /*fn decode(&self, chars: &[u8]) -> String {
         let encoding = self.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
@@ -830,36 +993,42 @@ impl<'a> PdfFont for PdfType3Font<'a> {
     }*/
 
     fn next_char(&self, iter: &mut Iter<u8>) -> Option<(CharCode, u8)> {
-        iter.next().map(|x| (*x as CharCode, 1))
+        iter.next().map(|x| (CharCode::from(*x), 1))
     }
     fn decode_char(&self, char: CharCode) -> String {
         let slice = [char as u8];
         if let Some(ref unicode_map) = self.unicode_map {
             let s = unicode_map.get(&char);
-            let s = match s {
-                None => {
-                    println!("missing char {:?} in unicode map {:?} for {:?}", char, unicode_map, self.font);
+            let s = s.map_or_else(
+                || {
+                    println!(
+                        "missing char {:?} in unicode map {:?} for {:?}",
+                        char, unicode_map, self.font
+                    );
                     // some pdf's like http://arxiv.org/pdf/2312.00577v1 are missing entries in their unicode map but do have
                     // entries in the encoding.
-                    let encoding = self.encoding.as_ref().map(|x| &x[..]).expect("missing unicode map and encoding");
+                    let encoding = self
+                        .encoding
+                        .as_ref()
+                        .map(|x| &x[..])
+                        .expect("missing unicode map and encoding");
                     let s = to_utf8(encoding, &slice);
-                    println!("falling back to encoding {} -> {:?}", char, s);
+                    println!("falling back to encoding {char} -> {s:?}");
                     s
-                }
-                Some(s) => { s.clone() }
-            };
-            return s
+                },
+                |s| s.clone(),
+            );
+
+            return s;
         }
-        let encoding = self.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
+        let encoding = self.encoding.as_ref().map_or(PDFDocEncoding, |x| &x[..]);
         //dlog!("char_code {:?} {:?}", char, self.encoding);
-        let s = to_utf8(encoding, &slice);
-        s
+
+        to_utf8(encoding, &slice)
     }
 }
 
-
-
-impl<'a> fmt::Debug for PdfType3Font<'a> {
+impl fmt::Debug for PdfType3Font<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.font.fmt(f)
     }
@@ -881,7 +1050,7 @@ fn get_unicode_map<'a>(doc: &'a Document, font: &'a Dictionary) -> Option<HashMa
     dlog!("ToUnicode: {:?}", to_unicode);
     let mut unicode_map = None;
     match to_unicode {
-        Some(&Object::Stream(ref stream)) => {
+        Some(Object::Stream(stream)) => {
             let contents = get_contents(stream);
             dlog!("Stream: {}", String::from_utf8(contents.clone()).unwrap());
 
@@ -890,21 +1059,18 @@ fn get_unicode_map<'a>(doc: &'a Document, font: &'a Dictionary) -> Option<HashMa
             // "It must use the beginbfchar, endbfchar, beginbfrange, and endbfrange operators to
             // define the mapping from character codes to Unicode character sequences expressed in
             // UTF-16BE encoding."
-            for (&k, v) in cmap.iter() {
+            for (&k, v) in &cmap {
                 let mut be: Vec<u16> = Vec::new();
                 let mut i = 0;
                 assert!(v.len() % 2 == 0);
                 while i < v.len() {
-                    be.push(((v[i] as u16) << 8) | v[i+1] as u16);
+                    be.push((u16::from(v[i]) << 8) | u16::from(v[i + 1]));
                     i += 2;
                 }
-                match &be[..] {
-                    [0xd800 ..= 0xdfff] => {
-                        // this range is not specified as not being encoded
-                        // we ignore them so we don't an error from from_utt16
-                        continue;
-                    }
-                    _ => {}
+                if let [0xd800..=0xdfff] = &be[..] {
+                    // this range is not specified as not being encoded
+                    // we ignore them so we don't an error from from_utt16
+                    continue;
                 }
                 let s = String::from_utf16(&be).unwrap();
 
@@ -914,43 +1080,61 @@ fn get_unicode_map<'a>(doc: &'a Document, font: &'a Dictionary) -> Option<HashMa
 
             dlog!("map: {:?}", unicode_map);
         }
-        None => { }
-        Some(&Object::Name(ref name)) => {
+        None => {}
+        Some(Object::Name(name)) => {
             let name = pdf_to_utf8(name);
             if name != "Identity-H" {
                 todo!("unsupported ToUnicode name: {:?}", name);
             }
         }
-        _ => { panic!("unsupported cmap {:?}", to_unicode)}
+        _ => {
+            panic!("unsupported cmap {:?}", to_unicode)
+        }
     }
     unicode_map
 }
 
-
 impl<'a> PdfCIDFont<'a> {
-    fn new(doc: &'a Document, font: &'a Dictionary) -> PdfCIDFont<'a> {
+    fn new(doc: &'a Document, font: &'a Dictionary) -> Self {
         let base_name = get_name_string(doc, font, b"BaseFont");
-        let descendants = maybe_get_array(doc, font, b"DescendantFonts").expect("Descendant fonts required");
-        let ciddict = maybe_deref(doc, &descendants[0]).as_dict().expect("should be CID dict");
-        let encoding = maybe_get_obj(doc, font, b"Encoding").expect("Encoding required in type0 fonts");
+        let descendants =
+            maybe_get_array(doc, font, b"DescendantFonts").expect("Descendant fonts required");
+        let ciddict = maybe_deref(doc, &descendants[0])
+            .as_dict()
+            .expect("should be CID dict");
+        let encoding =
+            maybe_get_obj(doc, font, b"Encoding").expect("Encoding required in type0 fonts");
         dlog!("base_name {} {:?}", base_name, font);
 
         let encoding = match encoding {
-            &Object::Name(ref name) => {
+            Object::Name(name) => {
                 let name = pdf_to_utf8(name);
                 dlog!("encoding {:?}", name);
                 if name == "Identity-H" || name == "Identity-V" {
-                    ByteMapping { codespace: vec![CodeRange{width: 2, start: 0, end: 0xffff }], cid: vec![CIDRange{ src_code_lo: 0, src_code_hi: 0xffff, dst_CID_lo: 0 }]}
+                    ByteMapping {
+                        codespace: vec![CodeRange {
+                            width: 2,
+                            start: 0,
+                            end: 0xffff,
+                        }],
+                        cid: vec![CIDRange {
+                            src_code_lo: 0,
+                            src_code_hi: 0xffff,
+                            dst_CID_lo: 0,
+                        }],
+                    }
                 } else {
                     panic!("unsupported encoding {}", name);
                 }
             }
-            &Object::Stream(ref stream) => {
+            Object::Stream(stream) => {
                 let contents = get_contents(stream);
                 dlog!("Stream: {}", String::from_utf8(contents.clone()).unwrap());
                 adobe_cmap_parser::get_byte_mapping(&contents).unwrap()
             }
-            _ => { panic!("unsupported encoding {:?}", encoding)}
+            _ => {
+                panic!("unsupported encoding {:?}", encoding)
+            }
         };
 
         // Sometimes a Type0 font might refer to the same underlying data as regular font. In this case we may be able to extract some encoding
@@ -972,19 +1156,17 @@ impl<'a> PdfCIDFont<'a> {
         let mut i = 0;
         if let Some(w) = w {
             while i < w.len() {
-                if let &Object::Array(ref wa) = w[i+1] {
+                if let Object::Array(wa) = w[i + 1] {
                     let cid = w[i].as_i64().expect("id should be num");
-                    let mut j = 0;
                     dlog!("wa: {:?} -> {:?}", cid, wa);
-                    for w in wa {
-                        widths.insert((cid + j) as CharCode, as_num(w) );
-                        j += 1;
+                    for (j, w) in wa.iter().enumerate() {
+                        widths.insert((cid + j as i64) as CharCode, as_num(w));
                     }
                     i += 2;
                 } else {
                     let c_first = w[i].as_i64().expect("first should be num");
                     let c_last = w[i].as_i64().expect("last should be num");
-                    let c_width = as_num(&w[i]);
+                    let c_width = as_num(w[i]);
                     for id in c_first..c_last {
                         widths.insert(id as CharCode, c_width);
                     }
@@ -992,42 +1174,52 @@ impl<'a> PdfCIDFont<'a> {
                 }
             }
         }
-        PdfCIDFont{doc, font, widths, to_unicode: unicode_map, encoding, default_width: Some(default_width as f64) }
+        PdfCIDFont {
+            doc,
+            font,
+            widths,
+            to_unicode: unicode_map,
+            encoding,
+            default_width: Some(default_width as f64),
+        }
     }
 }
 
-impl<'a> PdfFont for PdfCIDFont<'a> {
+impl PdfFont for PdfCIDFont<'_> {
     fn get_width(&self, id: CharCode) -> f64 {
         let width = self.widths.get(&id);
-        if let Some(width) = width {
-            dlog!("GetWidth {} -> {}", id, *width);
-            return *width;
-        } else {
-            dlog!("missing width for {} falling back to default_width", id);
-            return self.default_width.unwrap();
-        }
-    }/*
-    fn decode(&self, chars: &[u8]) -> String {
-        self.char_codes(chars);
+        width.map_or_else(
+            || {
+                dlog!("missing width for {} falling back to default_width", id);
+                self.default_width.unwrap()
+            },
+            |width| {
+                dlog!("GetWidth {} -> {}", id, *width);
+                *width
+            },
+        )
+    } /*
+      fn decode(&self, chars: &[u8]) -> String {
+          self.char_codes(chars);
 
-        //let utf16 = Vec::new();
+          //let utf16 = Vec::new();
 
-        let encoding = self.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
-        to_utf8(encoding, chars)
-    }*/
+          let encoding = self.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
+          to_utf8(encoding, chars)
+      }*/
 
     fn next_char(&self, iter: &mut Iter<u8>) -> Option<(CharCode, u8)> {
-        let mut c = *iter.next()? as u32;
+        let mut c = u32::from(*iter.next()?);
         let mut code = None;
         'outer: for width in 1..=4 {
             for range in &self.encoding.codespace {
-                if c as u32 >= range.start && c as u32 <= range.end && range.width == width {
-                    code = Some((c as u32, width));
+                if c >= range.start && c <= range.end && range.width == width {
+                    code = Some((c, width));
                     break 'outer;
                 }
             }
             let next = *iter.next()?;
-            c = ((c as u32) << 8) | next as u32;
+            c = (c << 8) | u32::from(next);
         }
         let code = code?;
         for range in &self.encoding.cid {
@@ -1039,27 +1231,31 @@ impl<'a> PdfFont for PdfCIDFont<'a> {
     }
     fn decode_char(&self, char: CharCode) -> String {
         let s = self.to_unicode.as_ref().and_then(|x| x.get(&char));
-        if let Some(s) = s {
-            s.clone()
-        } else {
-            dlog!("Unknown character {:?} in {:?} {:?}", char, self.font, self.to_unicode);
-            "".to_string()
-        }
+        s.map_or_else(
+            || {
+                dlog!(
+                    "Unknown character {:?} in {:?} {:?}",
+                    char,
+                    self.font,
+                    self.to_unicode
+                );
+                String::new()
+            },
+            std::clone::Clone::clone,
+        )
     }
 }
 
-impl<'a> fmt::Debug for PdfCIDFont<'a> {
+impl fmt::Debug for PdfCIDFont<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.font.fmt(f)
     }
 }
 
-
-
 #[derive(Copy, Clone)]
 struct PdfFontDescriptor<'a> {
     desc: &'a Dictionary,
-    doc: &'a Document
+    doc: &'a Document,
 }
 
 impl<'a> PdfFontDescriptor<'a> {
@@ -1069,7 +1265,7 @@ impl<'a> PdfFontDescriptor<'a> {
     }
 }
 
-impl<'a> fmt::Debug for PdfFontDescriptor<'a> {
+impl fmt::Debug for PdfFontDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.desc.fmt(f)
     }
@@ -1089,12 +1285,12 @@ struct Type0Func {
 #[allow(dead_code)]
 fn interpolate(x: f64, x_min: f64, _x_max: f64, y_min: f64, y_max: f64) -> f64 {
     let divisor = x - x_min;
-    if divisor != 0. {
-        y_min + (x - x_min) * ((y_max - y_min) / divisor)
-    } else {
+    if divisor == 0. {
         // (x - x_min) will be 0 which means we want to discard the interpolation
         // and arbitrarily choose y_min to match pdfium
         y_min
+    } else {
+        (x - x_min).mul_add((y_max - y_min) / divisor, y_min)
     }
 }
 
@@ -1103,7 +1299,6 @@ impl Type0Func {
     fn eval(&self, _input: &[f64], _output: &mut [f64]) {
         let _n_inputs = self.domain.len() / 2;
         let _n_ouputs = self.range.len() / 2;
-
     }
 }
 
@@ -1121,22 +1316,23 @@ enum Function {
     #[allow(dead_code)]
     Type3,
     #[allow(dead_code)]
-    Type4
+    Type4,
 }
 
 impl Function {
-    fn new(doc: &Document, obj: &Object) -> Function {
+    fn new(doc: &Document, obj: &Object) -> Self {
         let dict = match obj {
-            &Object::Dictionary(ref dict) => dict,
-            &Object::Stream(ref stream) => &stream.dict,
-            _ => panic!()
+            Object::Dictionary(dict) => dict,
+            Object::Stream(stream) => &stream.dict,
+            _ => panic!(),
         };
         let function_type: i64 = get(doc, dict, b"FunctionType");
-        let f = match function_type {
+
+        match function_type {
             0 => {
                 let stream = match obj {
-                    &Object::Stream(ref stream) => stream,
-                    _ => panic!()
+                    Object::Stream(stream) => stream,
+                    _ => panic!(),
                 };
                 let range: Vec<f64> = get(doc, dict, b"Range");
                 let domain: Vec<f64> = get(doc, dict, b"Domain");
@@ -1154,33 +1350,44 @@ impl Function {
                     }
                     default
                 });
-                let decode = get::<Option<Vec<f64>>>(doc, dict, b"Decode").unwrap_or_else(|| range.clone());
+                let decode =
+                    get::<Option<Vec<f64>>>(doc, dict, b"Decode").unwrap_or_else(|| range.clone());
 
-                Function::Type0(Type0Func { domain, range, size, contents, bits_per_sample, encode, decode })
+                Self::Type0(Type0Func {
+                    domain,
+                    range,
+                    contents,
+                    size,
+                    bits_per_sample,
+                    encode,
+                    decode,
+                })
             }
             2 => {
                 let c0 = get::<Option<Vec<f64>>>(doc, dict, b"C0");
                 let c1 = get::<Option<Vec<f64>>>(doc, dict, b"C1");
                 let n = get::<f64>(doc, dict, b"N");
-                Function::Type2(Type2Func { c0, c1, n})
+                Self::Type2(Type2Func { c0, c1, n })
             }
-            _ => { panic!("unhandled function type {}", function_type) }
-        };
-        f
+            _ => {
+                panic!("unhandled function type {}", function_type)
+            }
+        }
     }
 }
 
 fn as_num(o: &Object) -> f64 {
-    match o {
-        &Object::Integer(i) => { i as f64 }
-        &Object::Real(f) => { f.into() }
-        _ => { panic!("not a number") }
+    match *o {
+        Object::Integer(i) => i as f64,
+        Object::Real(f) => f.into(),
+        _ => {
+            panic!("not a number")
+        }
     }
 }
 
 #[derive(Clone)]
-struct TextState<'a>
-{
+struct TextState<'a> {
     font: Option<Rc<dyn PdfFont + 'a>>,
     font_size: f64,
     character_spacing: f64,
@@ -1194,15 +1401,16 @@ struct TextState<'a>
 // XXX: We'd ideally implement this without having to copy the uncompressed data
 fn get_contents(contents: &Stream) -> Vec<u8> {
     if contents.filter().is_ok() {
-        contents.decompressed_content().unwrap_or_else(|_|contents.content.clone())
+        contents
+            .decompressed_content()
+            .unwrap_or_else(|_| contents.content.clone())
     } else {
         contents.content.clone()
     }
 }
 
 #[derive(Clone)]
-struct GraphicsState<'a>
-{
+struct GraphicsState<'a> {
     ctm: Transform,
     ts: TextState<'a>,
     smask: Option<Dictionary>,
@@ -1213,10 +1421,13 @@ struct GraphicsState<'a>
     line_width: f64,
 }
 
-fn show_text(gs: &mut GraphicsState, s: &[u8],
-             _tlm: &Transform,
-             _flip_ctm: &Transform,
-             output: &mut dyn OutputDev) -> Result<(), OutputError> {
+fn show_text(
+    gs: &mut GraphicsState,
+    s: &[u8],
+    _tlm: &Transform,
+    _flip_ctm: &Transform,
+    output: &mut dyn OutputDev,
+) -> Result<(), OutputError> {
     let ts = &mut gs.ts;
     let font = ts.font.as_ref().unwrap();
     //let encoding = font.encoding.as_ref().map(|x| &x[..]).unwrap_or(&PDFDocEncoding);
@@ -1227,18 +1438,12 @@ fn show_text(gs: &mut GraphicsState, s: &[u8],
 
     for (c, length) in font.char_codes(s) {
         // 5.3.3 Text Space Details
-        let tsm = Transform2D::row_major(ts.horizontal_scaling,
-                                                 0.,
-                                                 0.,
-                                                 1.0,
-                                                 0.,
-                                                 ts.rise);
+        let tsm = Transform2D::row_major(ts.horizontal_scaling, 0., 0., 1.0, 0., ts.rise);
         // Trm = Tsm × Tm × CTM
         let trm = tsm.post_transform(&ts.tm.post_transform(&gs.ctm));
         //dlog!("ctm: {:?} tm {:?}", gs.ctm, tm);
         //dlog!("current pos: {:?}", position);
         // 5.9 Extraction of Text Content
-
 
         //dlog!("w: {}", font.widths[&(*c as i64)]);
         let w0 = font.get_width(c) / 1000.;
@@ -1249,18 +1454,28 @@ fn show_text(gs: &mut GraphicsState, s: &[u8],
         //  single-byte code. It does not apply to occurrences of the byte value 32 in
         //  multiple-byte codes."
         let is_space = c == 32 && length == 1;
-        if is_space { spacing += ts.word_spacing }
+        if is_space {
+            spacing += ts.word_spacing;
+        }
 
         output.output_character(&trm, w0, spacing, ts.font_size, &font.decode_char(c))?;
         let tj = 0.;
         let ty = 0.;
-        let tx = ts.horizontal_scaling * ((w0 - tj/1000.)* ts.font_size + spacing);
-        dlog!("horizontal {} adjust {} {} {} {}", ts.horizontal_scaling, tx, w0, ts.font_size, spacing);
+        let tx = ts.horizontal_scaling * (w0 - tj / 1000.).mul_add(ts.font_size, spacing);
+        dlog!(
+            "horizontal {} adjust {} {} {} {}",
+            ts.horizontal_scaling,
+            tx,
+            w0,
+            ts.font_size,
+            spacing
+        );
         // dlog!("w0: {}, tx: {}", w0, tx);
-        ts.tm = ts.tm.pre_transform(&Transform2D::create_translation(tx, ty));
+        ts.tm = ts
+            .tm
+            .pre_transform(&Transform2D::create_translation(tx, ty));
         let _trm = ts.tm.pre_transform(&gs.ctm);
         //dlog!("post pos: {:?}", trm);
-
     }
     output.end_word()?;
     Ok(())
@@ -1271,36 +1486,41 @@ pub struct MediaBox {
     pub llx: f64,
     pub lly: f64,
     pub urx: f64,
-    pub ury: f64
+    pub ury: f64,
 }
 
 fn apply_state(doc: &Document, gs: &mut GraphicsState, state: &Dictionary) {
-    for (k, v) in state.iter() {
-        let k : &[u8] = k.as_ref();
+    for (k, v) in state {
+        let k: &[u8] = k.as_ref();
         match k {
-            b"SMask" => { match maybe_deref(doc, v)  {
-                &Object::Name(ref name) => {
+            b"SMask" => match *maybe_deref(doc, v) {
+                Object::Name(ref name) => {
                     if name == b"None" {
                         gs.smask = None;
                     } else {
                         panic!("unexpected smask name")
                     }
                 }
-                &Object::Dictionary(ref dict) => {
+                Object::Dictionary(ref dict) => {
                     gs.smask = Some(dict.clone());
                 }
-                _ => { panic!("unexpected smask type {:?}", v) }
-            }}
-            b"Type" => { match v {
-                &Object::Name(ref name) => {
-                    assert_eq!(name, b"ExtGState")
+                _ => {
+                    panic!("unexpected smask type {:?}", v)
                 }
-                _ => { panic!("unexpected type") }
-            }}
-            _ => {  dlog!("unapplied state: {:?} {:?}", k, v); }
+            },
+            b"Type" => match v {
+                Object::Name(name) => {
+                    assert_eq!(name, b"ExtGState");
+                }
+                _ => {
+                    panic!("unexpected type")
+                }
+            },
+            _ => {
+                dlog!("unapplied state: {:?} {:?}", k, v);
+            }
         }
     }
-
 }
 
 #[derive(Debug)]
@@ -1315,19 +1535,21 @@ pub enum PathOp {
 
 #[derive(Debug)]
 pub struct Path {
-    pub ops: Vec<PathOp>
+    pub ops: Vec<PathOp>,
 }
 
 impl Path {
-    fn new() -> Path {
-        Path { ops: Vec::new() }
+    fn new() -> Self {
+        Self { ops: Vec::new() }
     }
     fn current_point(&self) -> (f64, f64) {
-        match self.ops.last().unwrap() {
-            &PathOp::MoveTo(x, y) => { (x, y) }
-            &PathOp::LineTo(x, y) => { (x, y) }
-            &PathOp::CurveTo(_, _, _, _, x, y) => { (x, y) }
-            _ => { panic!() }
+        match *self.ops.last().unwrap() {
+            PathOp::MoveTo(x, y) => (x, y),
+            PathOp::LineTo(x, y) => (x, y),
+            PathOp::CurveTo(_, _, _, _, x, y) => (x, y),
+            _ => {
+                panic!()
+            }
         }
     }
 }
@@ -1344,7 +1566,7 @@ pub struct CalRGB {
     white_point: [f64; 3],
     black_point: Option<[f64; 3]>,
     gamma: Option<[f64; 3]>,
-    matrix: Option<Vec<f64>>
+    matrix: Option<Vec<f64>>,
 }
 
 #[derive(Clone, Debug)]
@@ -1362,7 +1584,7 @@ pub enum AlternateColorSpace {
     CalRGB(CalRGB),
     CalGray(CalGray),
     Lab(Lab),
-    ICCBased(Vec<u8>)
+    ICCBased(Vec<u8>),
 }
 
 #[derive(Clone)]
@@ -1383,7 +1605,7 @@ pub enum ColorSpace {
     CalGray(CalGray),
     Lab(Lab),
     Separation(Separation),
-    ICCBased(Vec<u8>)
+    ICCBased(Vec<u8>),
 }
 
 fn make_colorspace<'a>(doc: &'a Document, name: &[u8], resources: &'a Dictionary) -> ColorSpace {
@@ -1393,137 +1615,161 @@ fn make_colorspace<'a>(doc: &'a Document, name: &[u8], resources: &'a Dictionary
         b"DeviceCMYK" => ColorSpace::DeviceCMYK,
         b"Pattern" => ColorSpace::Pattern,
         _ => {
-            let colorspaces: &Dictionary = get(&doc, resources, b"ColorSpace");
-            let cs: &Object = maybe_get_obj(doc, colorspaces, &name[..]).unwrap_or_else(|| panic!("missing colorspace {:?}", &name[..]));
-            if let Ok(cs) = cs.as_array() {
-                let cs_name = pdf_to_utf8(cs[0].as_name().expect("first arg must be a name"));
-                match cs_name.as_ref() {
-                    "Separation" => {
-                        let name = pdf_to_utf8(cs[1].as_name().expect("second arg must be a name"));
-                        let alternate_space = match &maybe_deref(doc, &cs[2]) {
-                            Object::Name(name) => {
-                                match &name[..] {
+            let colorspaces: &Dictionary = get(doc, resources, b"ColorSpace");
+            let cs: &Object = maybe_get_obj(doc, colorspaces, name)
+                .unwrap_or_else(|| panic!("missing colorspace {:?}", name));
+
+            cs.as_array().map_or_else(
+                |_| {
+                    cs.as_name().map_or_else(
+                        |_| {
+                            panic!();
+                        },
+                        |cs| match pdf_to_utf8(cs).as_ref() {
+                            "DeviceRGB" => ColorSpace::DeviceRGB,
+                            "DeviceGray" => ColorSpace::DeviceGray,
+                            _ => panic!(),
+                        },
+                    )
+                },
+                |cs| {
+                    let cs_name = pdf_to_utf8(cs[0].as_name().expect("first arg must be a name"));
+                    match cs_name.as_ref() {
+                        "Separation" => {
+                            let name =
+                                pdf_to_utf8(cs[1].as_name().expect("second arg must be a name"));
+                            let alternate_space = match &maybe_deref(doc, &cs[2]) {
+                                Object::Name(name) => match &name[..] {
                                     b"DeviceGray" => AlternateColorSpace::DeviceGray,
                                     b"DeviceRGB" => AlternateColorSpace::DeviceRGB,
                                     b"DeviceCMYK" => AlternateColorSpace::DeviceCMYK,
-                                    _ => panic!("unexpected color space name")
+                                    _ => panic!("unexpected color space name"),
+                                },
+                                Object::Array(cs) => {
+                                    let cs_name = pdf_to_utf8(
+                                        cs[0].as_name().expect("first arg must be a name"),
+                                    );
+                                    match cs_name.as_ref() {
+                                        "ICCBased" => {
+                                            let stream =
+                                                maybe_deref(doc, &cs[1]).as_stream().unwrap();
+                                            dlog!("ICCBased {:?}", stream);
+                                            // XXX: we're going to be continually decompressing everytime this object is referenced
+                                            AlternateColorSpace::ICCBased(get_contents(stream))
+                                        }
+                                        "CalGray" => {
+                                            let dict =
+                                                cs[1].as_dict().expect("second arg must be a dict");
+                                            AlternateColorSpace::CalGray(CalGray {
+                                                white_point: get(doc, dict, b"WhitePoint"),
+                                                black_point: get(doc, dict, b"BackPoint"),
+                                                gamma: get(doc, dict, b"Gamma"),
+                                            })
+                                        }
+                                        "CalRGB" => {
+                                            let dict =
+                                                cs[1].as_dict().expect("second arg must be a dict");
+                                            AlternateColorSpace::CalRGB(CalRGB {
+                                                white_point: get(doc, dict, b"WhitePoint"),
+                                                black_point: get(doc, dict, b"BackPoint"),
+                                                gamma: get(doc, dict, b"Gamma"),
+                                                matrix: get(doc, dict, b"Matrix"),
+                                            })
+                                        }
+                                        "Lab" => {
+                                            let dict =
+                                                cs[1].as_dict().expect("second arg must be a dict");
+                                            AlternateColorSpace::Lab(Lab {
+                                                white_point: get(doc, dict, b"WhitePoint"),
+                                                black_point: get(doc, dict, b"BackPoint"),
+                                                range: get(doc, dict, b"Range"),
+                                            })
+                                        }
+                                        _ => panic!("Unexpected color space name"),
+                                    }
                                 }
-                            }
-                            Object::Array(cs) => {
-                                let cs_name = pdf_to_utf8(cs[0].as_name().expect("first arg must be a name"));
-                                match cs_name.as_ref() {
-                                    "ICCBased" => {
-                                        let stream = maybe_deref(doc, &cs[1]).as_stream().unwrap();
-                                        dlog!("ICCBased {:?}", stream);
-                                        // XXX: we're going to be continually decompressing everytime this object is referenced
-                                        AlternateColorSpace::ICCBased(get_contents(stream))
-                                    }
-                                    "CalGray" => {
-                                        let dict = cs[1].as_dict().expect("second arg must be a dict");
-                                        AlternateColorSpace::CalGray(CalGray {
-                                            white_point: get(&doc, dict, b"WhitePoint"),
-                                            black_point: get(&doc, dict, b"BackPoint"),
-                                            gamma: get(&doc, dict, b"Gamma"),
-                                        })
-                                    }
-                                    "CalRGB" => {
-                                        let dict = cs[1].as_dict().expect("second arg must be a dict");
-                                        AlternateColorSpace::CalRGB(CalRGB {
-                                            white_point: get(&doc, dict, b"WhitePoint"),
-                                            black_point: get(&doc, dict, b"BackPoint"),
-                                            gamma: get(&doc, dict, b"Gamma"),
-                                            matrix: get(&doc, dict, b"Matrix"),
-                                        })
-                                    }
-                                    "Lab" => {
-                                        let dict = cs[1].as_dict().expect("second arg must be a dict");
-                                        AlternateColorSpace::Lab(Lab {
-                                            white_point: get(&doc, dict, b"WhitePoint"),
-                                            black_point: get(&doc, dict, b"BackPoint"),
-                                            range: get(&doc, dict, b"Range"),
-                                        })
-                                    }
-                                    _ => panic!("Unexpected color space name")
-                                }
-                            }
-                            _ => panic!("Alternate space should be name or array {:?}", cs[2])
-                        };
-                        let tint_transform = Box::new(Function::new(doc, maybe_deref(doc, &cs[3])));
+                                _ => panic!("Alternate space should be name or array {:?}", cs[2]),
+                            };
+                            let tint_transform =
+                                Box::new(Function::new(doc, maybe_deref(doc, &cs[3])));
 
-                        dlog!("{:?} {:?} {:?}", name, alternate_space, tint_transform);
-                        ColorSpace::Separation(Separation{ name, alternate_space, tint_transform})
+                            dlog!("{:?} {:?} {:?}", name, alternate_space, tint_transform);
+                            ColorSpace::Separation(Separation {
+                                name,
+                                alternate_space,
+                                tint_transform,
+                            })
+                        }
+                        "ICCBased" => {
+                            let stream = maybe_deref(doc, &cs[1]).as_stream().unwrap();
+                            dlog!("ICCBased {:?}", stream);
+                            // XXX: we're going to be continually decompressing everytime this object is referenced
+                            ColorSpace::ICCBased(get_contents(stream))
+                        }
+                        "CalGray" => {
+                            let dict = cs[1].as_dict().expect("second arg must be a dict");
+                            ColorSpace::CalGray(CalGray {
+                                white_point: get(doc, dict, b"WhitePoint"),
+                                black_point: get(doc, dict, b"BackPoint"),
+                                gamma: get(doc, dict, b"Gamma"),
+                            })
+                        }
+                        "CalRGB" => {
+                            let dict = cs[1].as_dict().expect("second arg must be a dict");
+                            ColorSpace::CalRGB(CalRGB {
+                                white_point: get(doc, dict, b"WhitePoint"),
+                                black_point: get(doc, dict, b"BackPoint"),
+                                gamma: get(doc, dict, b"Gamma"),
+                                matrix: get(doc, dict, b"Matrix"),
+                            })
+                        }
+                        "Lab" => {
+                            let dict = cs[1].as_dict().expect("second arg must be a dict");
+                            ColorSpace::Lab(Lab {
+                                white_point: get(doc, dict, b"WhitePoint"),
+                                black_point: get(doc, dict, b"BackPoint"),
+                                range: get(doc, dict, b"Range"),
+                            })
+                        }
+                        "Pattern" => ColorSpace::Pattern,
+                        "DeviceGray" => ColorSpace::DeviceGray,
+                        "DeviceRGB" => ColorSpace::DeviceRGB,
+                        "DeviceCMYK" => ColorSpace::DeviceCMYK,
+                        "DeviceN" => ColorSpace::DeviceN,
+                        _ => {
+                            panic!("color_space {:?} {:?} {:?}", name, cs_name, cs)
+                        }
                     }
-                    "ICCBased" => {
-                        let stream = maybe_deref(doc, &cs[1]).as_stream().unwrap();
-                        dlog!("ICCBased {:?}", stream);
-                        // XXX: we're going to be continually decompressing everytime this object is referenced
-                        ColorSpace::ICCBased(get_contents(stream))
-                    }
-                    "CalGray" => {
-                        let dict = cs[1].as_dict().expect("second arg must be a dict");
-                        ColorSpace::CalGray(CalGray {
-                            white_point: get(&doc, dict, b"WhitePoint"),
-                            black_point: get(&doc, dict, b"BackPoint"),
-                            gamma: get(&doc, dict, b"Gamma"),
-                        })
-                    }
-                    "CalRGB" => {
-                        let dict = cs[1].as_dict().expect("second arg must be a dict");
-                        ColorSpace::CalRGB(CalRGB {
-                            white_point: get(&doc, dict, b"WhitePoint"),
-                            black_point: get(&doc, dict, b"BackPoint"),
-                            gamma: get(&doc, dict, b"Gamma"),
-                            matrix: get(&doc, dict, b"Matrix"),
-                        })
-                    }
-                    "Lab" => {
-                        let dict = cs[1].as_dict().expect("second arg must be a dict");
-                        ColorSpace::Lab(Lab {
-                            white_point: get(&doc, dict, b"WhitePoint"),
-                            black_point: get(&doc, dict, b"BackPoint"),
-                            range: get(&doc, dict, b"Range"),
-                        })
-                    }
-                    "Pattern" => {
-                        ColorSpace::Pattern
-                    },
-                    "DeviceGray" => ColorSpace::DeviceGray,
-                    "DeviceRGB" => ColorSpace::DeviceRGB,
-                    "DeviceCMYK" => ColorSpace::DeviceCMYK,
-                    "DeviceN" => ColorSpace::DeviceN,
-                    _ => {
-                        panic!("color_space {:?} {:?} {:?}", name, cs_name, cs)
-                    }
-                }
-            } else if let Ok(cs) = cs.as_name() {
-                match pdf_to_utf8(cs).as_ref() {
-                    "DeviceRGB" => ColorSpace::DeviceRGB,
-                    "DeviceGray" => ColorSpace::DeviceGray,
-                    _ => panic!()
-                }
-            } else {
-                panic!();
-            }
+                },
+            )
         }
     }
 }
 
 struct Processor<'a> {
-    _none: PhantomData<&'a ()>
+    _none: PhantomData<&'a ()>,
 }
 
 impl<'a> Processor<'a> {
-    fn new() -> Processor<'a> {
+    fn new() -> Self {
         Processor { _none: PhantomData }
     }
 
-    fn process_stream(&mut self, doc: &'a Document, content: Vec<u8>, resources: &'a Dictionary, media_box: &MediaBox, output: &mut dyn OutputDev, page_num: u32) -> Result<(), OutputError> {
-        let content = Content::decode(&content).unwrap();
+    fn process_stream(
+        &mut self,
+        doc: &'a Document,
+        content: &[u8],
+        resources: &'a Dictionary,
+        media_box: &MediaBox,
+        output: &mut dyn OutputDev,
+        page_num: u32,
+    ) -> Result<(), OutputError> {
+        let content = Content::decode(content).unwrap();
         let mut font_table = HashMap::new();
         let mut gs: GraphicsState = GraphicsState {
             ts: TextState {
                 font: None,
-                font_size: std::f64::NAN,
+                font_size: f64::NAN,
                 character_spacing: 0.,
                 word_spacing: 0.,
                 horizontal_scaling: 100. / 100.,
@@ -1537,7 +1783,7 @@ impl<'a> Processor<'a> {
             stroke_colorspace: ColorSpace::DeviceGray,
             line_width: 1.,
             ctm: Transform2D::identity(),
-            smask: None
+            smask: None,
         };
         //let mut ts = &mut gs.ts;
         let mut gs_stack = Vec::new();
@@ -1551,22 +1797,20 @@ impl<'a> Processor<'a> {
             //dlog!("op: {:?}", operation);
 
             match operation.operator.as_ref() {
-                "BT" => {
-                    tlm = Transform2D::identity();
-                    gs.ts.tm = tlm;
-                }
-                "ET" => {
+                "BT" | "ET" => {
                     tlm = Transform2D::identity();
                     gs.ts.tm = tlm;
                 }
                 "cm" => {
                     assert!(operation.operands.len() == 6);
-                    let m = Transform2D::row_major(as_num(&operation.operands[0]),
-                                                   as_num(&operation.operands[1]),
-                                                   as_num(&operation.operands[2]),
-                                                   as_num(&operation.operands[3]),
-                                                   as_num(&operation.operands[4]),
-                                                   as_num(&operation.operands[5]));
+                    let m = Transform2D::row_major(
+                        as_num(&operation.operands[0]),
+                        as_num(&operation.operands[1]),
+                        as_num(&operation.operands[2]),
+                        as_num(&operation.operands[3]),
+                        as_num(&operation.operands[4]),
+                        as_num(&operation.operands[5]),
+                    );
                     gs.ctm = gs.ctm.pre_transform(&m);
                     dlog!("matrix {:?}", gs.ctm);
                 }
@@ -1580,60 +1824,71 @@ impl<'a> Processor<'a> {
                 }
                 "SC" | "SCN" => {
                     gs.stroke_color = match gs.stroke_colorspace {
-                        ColorSpace::Pattern => { dlog!("unhandled pattern color"); Vec::new() }
-                        _ => { operation.operands.iter().map(|x| as_num(x)).collect() }
+                        ColorSpace::Pattern => {
+                            dlog!("unhandled pattern color");
+                            Vec::new()
+                        }
+                        _ => operation.operands.iter().map(as_num).collect(),
                     };
                 }
                 "sc" | "scn" => {
                     gs.fill_color = match gs.fill_colorspace {
-                        ColorSpace::Pattern => { dlog!("unhandled pattern color"); Vec::new() }
-                        _ => { operation.operands.iter().map(|x| as_num(x)).collect() }
+                        ColorSpace::Pattern => {
+                            dlog!("unhandled pattern color");
+                            Vec::new()
+                        }
+                        _ => operation.operands.iter().map(as_num).collect(),
                     };
                 }
                 "G" | "g" | "RG" | "rg" | "K" | "k" => {
                     dlog!("unhandled color operation {:?}", operation);
                 }
                 "TJ" => {
-                    match operation.operands[0] {
-                        Object::Array(ref array) => {
-                            for e in array {
-                                match e {
-                                    &Object::String(ref s, _) => {
-                                        show_text(&mut gs, s, &tlm, &flip_ctm, output)?;
-                                    }
-                                    &Object::Integer(i) => {
-                                        let ts = &mut gs.ts;
-                                        let w0 = 0.;
-                                        let tj = i as f64;
-                                        let ty = 0.;
-                                        let tx = ts.horizontal_scaling * ((w0 - tj / 1000.) * ts.font_size);
-                                        ts.tm = ts.tm.pre_transform(&Transform2D::create_translation(tx, ty));
-                                        dlog!("adjust text by: {} {:?}", i, ts.tm);
-                                    }
-                                    &Object::Real(i) => {
-                                        let ts = &mut gs.ts;
-                                        let w0 = 0.;
-                                        let tj = i as f64;
-                                        let ty = 0.;
-                                        let tx = ts.horizontal_scaling * ((w0 - tj / 1000.) * ts.font_size);
-                                        ts.tm = ts.tm.pre_transform(&Transform2D::create_translation(tx, ty));
-                                        dlog!("adjust text by: {} {:?}", i, ts.tm);
-                                    }
-                                    _ => { dlog!("kind of {:?}", e); }
+                    if let Object::Array(ref array) = operation.operands[0] {
+                        for e in array {
+                            match *e {
+                                Object::String(ref s, _) => {
+                                    show_text(&mut gs, s, &tlm, &flip_ctm, output)?;
+                                }
+                                Object::Integer(i) => {
+                                    let ts = &mut gs.ts;
+                                    let w0 = 0.;
+                                    let tj = i as f64;
+                                    let ty = 0.;
+                                    let tx =
+                                        ts.horizontal_scaling * ((w0 - tj / 1000.) * ts.font_size);
+                                    ts.tm = ts
+                                        .tm
+                                        .pre_transform(&Transform2D::create_translation(tx, ty));
+                                    dlog!("adjust text by: {} {:?}", i, ts.tm);
+                                }
+                                Object::Real(i) => {
+                                    let ts = &mut gs.ts;
+                                    let w0 = 0.;
+                                    let tj = f64::from(i);
+                                    let ty = 0.;
+                                    let tx =
+                                        ts.horizontal_scaling * ((w0 - tj / 1000.) * ts.font_size);
+                                    ts.tm = ts
+                                        .tm
+                                        .pre_transform(&Transform2D::create_translation(tx, ty));
+                                    dlog!("adjust text by: {} {:?}", i, ts.tm);
+                                }
+                                _ => {
+                                    dlog!("kind of {:?}", e);
                                 }
                             }
                         }
-                        _ => {}
                     }
                 }
-                "Tj" => {
-                    match operation.operands[0] {
-                        Object::String(ref s, _) => {
-                            show_text(&mut gs, s, &tlm, &flip_ctm, output)?;
-                        }
-                        _ => { panic!("unexpected Tj operand {:?}", operation) }
+                "Tj" => match operation.operands[0] {
+                    Object::String(ref s, _) => {
+                        show_text(&mut gs, s, &tlm, &flip_ctm, output)?;
                     }
-                }
+                    _ => {
+                        panic!("unexpected Tj operand {:?}", operation)
+                    }
+                },
                 "Tc" => {
                     gs.ts.character_spacing = as_num(&operation.operands[0]);
                 }
@@ -1647,43 +1902,53 @@ impl<'a> Processor<'a> {
                     gs.ts.leading = as_num(&operation.operands[0]);
                 }
                 "Tf" => {
-                    let fonts: &Dictionary = get(&doc, resources, b"Font");
+                    let fonts: &Dictionary = get(doc, resources, b"Font");
                     let name = operation.operands[0].as_name().unwrap();
-                    let font = font_table.entry(name.to_owned()).or_insert_with(|| make_font(doc, get::<&Dictionary>(doc, fonts, name))).clone();
+                    let font = font_table
+                        .entry(name.to_owned())
+                        .or_insert_with(|| make_font(doc, get::<&Dictionary>(doc, fonts, name)))
+                        .clone();
                     {
                         /*let file = font.get_descriptor().and_then(|desc| desc.get_file());
-                    if let Some(file) = file {
-                        let file_contents = filter_data(file.as_stream().unwrap());
-                        let mut cursor = Cursor::new(&file_contents[..]);
-                        //let f = Font::read(&mut cursor);
-                        //dlog!("font file: {:?}", f);
-                    }*/
+                        if let Some(file) = file {
+                            let file_contents = filter_data(file.as_stream().unwrap());
+                            let mut cursor = Cursor::new(&file_contents[..]);
+                            //let f = Font::read(&mut cursor);
+                            //dlog!("font file: {:?}", f);
+                        }*/
                     }
                     gs.ts.font = Some(font);
 
                     gs.ts.font_size = as_num(&operation.operands[1]);
-                    dlog!("font {} size: {} {:?}", pdf_to_utf8(name), gs.ts.font_size, operation);
+                    dlog!(
+                        "font {} size: {} {:?}",
+                        pdf_to_utf8(name),
+                        gs.ts.font_size,
+                        operation
+                    );
                 }
                 "Ts" => {
                     gs.ts.rise = as_num(&operation.operands[0]);
                 }
                 "Tm" => {
                     assert!(operation.operands.len() == 6);
-                    tlm = Transform2D::row_major(as_num(&operation.operands[0]),
-                                                 as_num(&operation.operands[1]),
-                                                 as_num(&operation.operands[2]),
-                                                 as_num(&operation.operands[3]),
-                                                 as_num(&operation.operands[4]),
-                                                 as_num(&operation.operands[5]));
+                    tlm = Transform2D::row_major(
+                        as_num(&operation.operands[0]),
+                        as_num(&operation.operands[1]),
+                        as_num(&operation.operands[2]),
+                        as_num(&operation.operands[3]),
+                        as_num(&operation.operands[4]),
+                        as_num(&operation.operands[5]),
+                    );
                     gs.ts.tm = tlm;
                     dlog!("Tm: matrix {:?}", gs.ts.tm);
                     output.end_line()?;
                 }
                 "Td" => {
                     /* Move to the start of the next line, offset from the start of the current line by (tx , ty ).
-                   tx and ty are numbers expressed in unscaled text space units.
-                   More precisely, this operator performs the following assignments:
-                 */
+                      tx and ty are numbers expressed in unscaled text space units.
+                      More precisely, this operator performs the following assignments:
+                    */
                     assert!(operation.operands.len() == 2);
                     let tx = as_num(&operation.operands[0]);
                     let ty = as_num(&operation.operands[1]);
@@ -1697,8 +1962,8 @@ impl<'a> Processor<'a> {
 
                 "TD" => {
                     /* Move to the start of the next line, offset from the start of the current line by (tx , ty ).
-                   As a side effect, this operator sets the leading parameter in the text state.
-                 */
+                      As a side effect, this operator sets the leading parameter in the text state.
+                    */
                     assert!(operation.operands.len() == 2);
                     let tx = as_num(&operation.operands[0]);
                     let ty = as_num(&operation.operands[1]);
@@ -1720,7 +1985,9 @@ impl<'a> Processor<'a> {
                     dlog!("T* matrix {:?}", gs.ts.tm);
                     output.end_line()?;
                 }
-                "q" => { gs_stack.push(gs.clone()); }
+                "q" => {
+                    gs_stack.push(gs.clone());
+                }
                 "Q" => {
                     let s = gs_stack.pop();
                     if let Some(s) = s {
@@ -1735,20 +2002,34 @@ impl<'a> Processor<'a> {
                     let state: &Dictionary = get(doc, ext_gstate, name);
                     apply_state(doc, &mut gs, state);
                 }
-                "i" => { dlog!("unhandled graphics state flattness operator {:?}", operation); }
-                "w" => { gs.line_width = as_num(&operation.operands[0]); }
-                "J" | "j" | "M" | "d" | "ri"  => { dlog!("unknown graphics state operator {:?}", operation); }
-                "m" => { path.ops.push(PathOp::MoveTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
-                "l" => { path.ops.push(PathOp::LineTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
-                "c" => {
-                    path.ops.push(PathOp::CurveTo(
-                        as_num(&operation.operands[0]),
-                        as_num(&operation.operands[1]),
-                        as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3]),
-                        as_num(&operation.operands[4]),
-                        as_num(&operation.operands[5])))
+                "i" => {
+                    dlog!(
+                        "unhandled graphics state flattness operator {:?}",
+                        operation
+                    );
                 }
+                "w" => {
+                    gs.line_width = as_num(&operation.operands[0]);
+                }
+                "J" | "j" | "M" | "d" | "ri" => {
+                    dlog!("unknown graphics state operator {:?}", operation);
+                }
+                "m" => path.ops.push(PathOp::MoveTo(
+                    as_num(&operation.operands[0]),
+                    as_num(&operation.operands[1]),
+                )),
+                "l" => path.ops.push(PathOp::LineTo(
+                    as_num(&operation.operands[0]),
+                    as_num(&operation.operands[1]),
+                )),
+                "c" => path.ops.push(PathOp::CurveTo(
+                    as_num(&operation.operands[0]),
+                    as_num(&operation.operands[1]),
+                    as_num(&operation.operands[2]),
+                    as_num(&operation.operands[3]),
+                    as_num(&operation.operands[4]),
+                    as_num(&operation.operands[5]),
+                )),
                 "v" => {
                     let (x, y) = path.current_point();
                     path.ops.push(PathOp::CurveTo(
@@ -1757,24 +2038,24 @@ impl<'a> Processor<'a> {
                         as_num(&operation.operands[0]),
                         as_num(&operation.operands[1]),
                         as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3])))
-                }
-                "y" => {
-                    path.ops.push(PathOp::CurveTo(
-                        as_num(&operation.operands[0]),
-                        as_num(&operation.operands[1]),
-                        as_num(&operation.operands[2]),
                         as_num(&operation.operands[3]),
-                        as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3])))
+                    ));
                 }
-                "h" => { path.ops.push(PathOp::Close) }
-                "re" => {
-                    path.ops.push(PathOp::Rect(as_num(&operation.operands[0]),
-                                               as_num(&operation.operands[1]),
-                                               as_num(&operation.operands[2]),
-                                               as_num(&operation.operands[3])))
-                }
+                "y" => path.ops.push(PathOp::CurveTo(
+                    as_num(&operation.operands[0]),
+                    as_num(&operation.operands[1]),
+                    as_num(&operation.operands[2]),
+                    as_num(&operation.operands[3]),
+                    as_num(&operation.operands[2]),
+                    as_num(&operation.operands[3]),
+                )),
+                "h" => path.ops.push(PathOp::Close),
+                "re" => path.ops.push(PathOp::Rect(
+                    as_num(&operation.operands[0]),
+                    as_num(&operation.operands[1]),
+                    as_num(&operation.operands[2]),
+                    as_num(&operation.operands[3]),
+                )),
                 "s" | "f*" | "B" | "B*" | "b" => {
                     dlog!("unhandled path op {:?}", operation);
                 }
@@ -1786,7 +2067,9 @@ impl<'a> Processor<'a> {
                     output.fill(&gs.ctm, &gs.fill_colorspace, &gs.fill_color, &path)?;
                     path.ops.clear();
                 }
-                "W" | "w*" => { dlog!("unhandled clipping operation {:?}", operation); }
+                "W" | "w*" => {
+                    dlog!("unhandled clipping operation {:?}", operation);
+                }
                 "n" => {
                     dlog!("discard {:?}", path);
                     path.ops.clear();
@@ -1800,41 +2083,70 @@ impl<'a> Processor<'a> {
                 "Do" => {
                     // `Do` process an entire subdocument, so we do a recursive call to `process_stream`
                     // with the subdocument content and resources
-                    let xobject: &Dictionary = get(&doc, resources, b"XObject");
+                    let xobject: &Dictionary = get(doc, resources, b"XObject");
                     let name = operation.operands[0].as_name().unwrap();
-                    let xf: &Stream = get(&doc, xobject, name);
-                    let resources = maybe_get_obj(&doc, &xf.dict, b"Resources").and_then(|n| n.as_dict().ok()).unwrap_or(resources);
+                    let xf: &Stream = get(doc, xobject, name);
+                    let resources = maybe_get_obj(doc, &xf.dict, b"Resources")
+                        .and_then(|n| n.as_dict().ok())
+                        .unwrap_or(resources);
                     let contents = get_contents(xf);
-                    self.process_stream(&doc, contents, resources, &media_box, output, page_num)?;
+                    self.process_stream(doc, &contents, resources, media_box, output, page_num)?;
                 }
-                _ => { dlog!("unknown operation {:?}", operation); }
-
+                _ => {
+                    dlog!("unknown operation {:?}", operation);
+                }
             }
         }
         Ok(())
     }
 }
 
-
 pub trait OutputDev {
-    fn begin_page(&mut self, page_num: u32, media_box: &MediaBox, art_box: Option<(f64, f64, f64, f64)>)-> Result<(), OutputError>;
-    fn end_page(&mut self)-> Result<(), OutputError>;
-    fn output_character(&mut self, trm: &Transform, width: f64, spacing: f64, font_size: f64, char: &str) -> Result<(), OutputError>;
-    fn begin_word(&mut self)-> Result<(), OutputError>;
-    fn end_word(&mut self)-> Result<(), OutputError>;
-    fn end_line(&mut self)-> Result<(), OutputError>;
-    fn stroke(&mut self, _ctm: &Transform, _colorspace: &ColorSpace, _color: &[f64], _path: &Path)-> Result<(), OutputError> {Ok(())}
-    fn fill(&mut self, _ctm: &Transform, _colorspace: &ColorSpace, _color: &[f64], _path: &Path)-> Result<(), OutputError> {Ok(())}
+    fn begin_page(
+        &mut self,
+        page_num: u32,
+        media_box: &MediaBox,
+        art_box: Option<(f64, f64, f64, f64)>,
+    ) -> Result<(), OutputError>;
+    fn end_page(&mut self) -> Result<(), OutputError>;
+    fn output_character(
+        &mut self,
+        trm: &Transform,
+        width: f64,
+        spacing: f64,
+        font_size: f64,
+        char: &str,
+    ) -> Result<(), OutputError>;
+    fn begin_word(&mut self) -> Result<(), OutputError>;
+    fn end_word(&mut self) -> Result<(), OutputError>;
+    fn end_line(&mut self) -> Result<(), OutputError>;
+    fn stroke(
+        &mut self,
+        _ctm: &Transform,
+        _colorspace: &ColorSpace,
+        _color: &[f64],
+        _path: &Path,
+    ) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn fill(
+        &mut self,
+        _ctm: &Transform,
+        _colorspace: &ColorSpace,
+        _color: &[f64],
+        _path: &Path,
+    ) -> Result<(), OutputError> {
+        Ok(())
+    }
 }
 
-
-pub struct HTMLOutput<'a>  {
+pub struct HTMLOutput<'a> {
     file: &'a mut dyn std::io::Write,
     flip_ctm: Transform,
     last_ctm: Transform,
     buf_ctm: Transform,
     buf_font_size: f64,
-    buf: String
+    buf: String,
 }
 
 fn insert_nbsp(input: &str) -> String {
@@ -1857,7 +2169,7 @@ fn insert_nbsp(input: &str) -> String {
     result
 }
 
-impl<'a> HTMLOutput<'a> {
+impl HTMLOutput<'_> {
     pub fn new(file: &mut dyn std::io::Write) -> HTMLOutput {
         HTMLOutput {
             file,
@@ -1868,18 +2180,26 @@ impl<'a> HTMLOutput<'a> {
             buf_font_size: 0.,
         }
     }
-    fn flush_string(&mut self) -> Result<(), OutputError>{
-        if self.buf.len() != 0 {
-
+    fn flush_string(&mut self) -> Result<(), OutputError> {
+        if !self.buf.is_empty() {
             let position = self.buf_ctm.post_transform(&self.flip_ctm);
-            let transformed_font_size_vec = self.buf_ctm.transform_vector(vec2(self.buf_font_size, self.buf_font_size));
+            let transformed_font_size_vec = self
+                .buf_ctm
+                .transform_vector(vec2(self.buf_font_size, self.buf_font_size));
             // get the length of one sized of the square with the same area with a rectangle of size (x, y)
-            let transformed_font_size = (transformed_font_size_vec.x * transformed_font_size_vec.y).sqrt();
+            let transformed_font_size =
+                (transformed_font_size_vec.x * transformed_font_size_vec.y).sqrt();
             let (x, y) = (position.m31, position.m32);
-            println!("flush {} {:?}", self.buf, (x,y));
+            println!("flush {} {:?}", self.buf, (x, y));
 
-            write!(self.file, "<div style='position: absolute; left: {}px; top: {}px; font-size: {}px'>{}</div>\n",
-                   x, y, transformed_font_size, insert_nbsp(&self.buf))?;
+            writeln!(
+                self.file,
+                "<div style='position: absolute; left: {}px; top: {}px; font-size: {}px'>{}</div>",
+                x,
+                y,
+                transformed_font_size,
+                insert_nbsp(&self.buf)
+            )?;
         }
         Ok(())
     }
@@ -1887,10 +2207,15 @@ impl<'a> HTMLOutput<'a> {
 
 type ArtBox = (f64, f64, f64, f64);
 
-impl<'a> OutputDev for HTMLOutput<'a> {
-    fn begin_page(&mut self, page_num: u32, media_box: &MediaBox, _: Option<ArtBox>) -> Result<(), OutputError> {
+impl OutputDev for HTMLOutput<'_> {
+    fn begin_page(
+        &mut self,
+        page_num: u32,
+        media_box: &MediaBox,
+        _: Option<ArtBox>,
+    ) -> Result<(), OutputError> {
         write!(self.file, "<meta charset='utf-8' /> ")?;
-        write!(self.file, "<!-- page {} -->", page_num)?;
+        write!(self.file, "<!-- page {page_num} -->")?;
         write!(self.file, "<div id='page{}' style='position: relative; height: {}px; width: {}px; border: 1px black solid'>", page_num, media_box.ury - media_box.lly, media_box.urx - media_box.llx)?;
         self.flip_ctm = Transform::row_major(1., 0., 0., -1., 0., media_box.ury - media_box.lly);
         Ok(())
@@ -1902,53 +2227,83 @@ impl<'a> OutputDev for HTMLOutput<'a> {
         write!(self.file, "</div>")?;
         Ok(())
     }
-    fn output_character(&mut self, trm: &Transform, width: f64, spacing: f64, font_size: f64, char: &str) -> Result<(), OutputError>{
+    fn output_character(
+        &mut self,
+        trm: &Transform,
+        width: f64,
+        spacing: f64,
+        font_size: f64,
+        char: &str,
+    ) -> Result<(), OutputError> {
         if trm.approx_eq(&self.last_ctm) {
             let position = trm.post_transform(&self.flip_ctm);
             let (x, y) = (position.m31, position.m32);
 
-            println!("accum {} {:?}", char, (x,y));
+            println!("accum {} {:?}", char, (x, y));
             self.buf += char;
         } else {
-            println!("flush {} {:?} {:?} {} {} {}", char, trm, self.last_ctm, width, font_size, spacing);
+            println!(
+                "flush {} {:?} {:?} {} {} {}",
+                char, trm, self.last_ctm, width, font_size, spacing
+            );
             self.flush_string()?;
-            self.buf = char.to_owned();
+            char.clone_into(&mut self.buf);
             self.buf_font_size = font_size;
             self.buf_ctm = *trm;
         }
         let position = trm.post_transform(&self.flip_ctm);
         let transformed_font_size_vec = trm.transform_vector(vec2(font_size, font_size));
         // get the length of one sized of the square with the same area with a rectangle of size (x, y)
-        let transformed_font_size = (transformed_font_size_vec.x * transformed_font_size_vec.y).sqrt();
+        let transformed_font_size =
+            (transformed_font_size_vec.x * transformed_font_size_vec.y).sqrt();
         let (x, y) = (position.m31, position.m32);
-        write!(self.file, "<div style='position: absolute; color: red; left: {}px; top: {}px; font-size: {}px'>{}</div>",
-               x, y, transformed_font_size, char)?;
-        self.last_ctm = trm.pre_transform(&Transform2D::create_translation(width * font_size + spacing, 0.));
+        write!(self.file, "<div style='position: absolute; color: red; left: {x}px; top: {y}px; font-size: {transformed_font_size}px'>{char}</div>")?;
+        self.last_ctm = trm.pre_transform(&Transform2D::create_translation(
+            width.mul_add(font_size, spacing),
+            0.,
+        ));
 
         Ok(())
     }
-    fn begin_word(&mut self) -> Result<(), OutputError> {Ok(())}
-    fn end_word(&mut self) -> Result<(), OutputError> {Ok(())}
-    fn end_line(&mut self) -> Result<(), OutputError> {Ok(())}
-}
-
-pub struct SVGOutput<'a>  {
-    file: &'a mut dyn std::io::Write
-}
-impl<'a> SVGOutput<'a> {
-    pub fn new(file: &mut dyn std::io::Write) -> SVGOutput {
-        SVGOutput{file}
+    fn begin_word(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn end_word(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn end_line(&mut self) -> Result<(), OutputError> {
+        Ok(())
     }
 }
 
-impl<'a> OutputDev for SVGOutput<'a> {
-    fn begin_page(&mut self, _page_num: u32, media_box: &MediaBox, art_box: Option<(f64, f64, f64, f64)>) -> Result<(), OutputError> {
+pub struct SVGOutput<'a> {
+    file: &'a mut dyn std::io::Write,
+}
+impl SVGOutput<'_> {
+    pub fn new(file: &mut dyn std::io::Write) -> SVGOutput {
+        SVGOutput { file }
+    }
+}
+
+impl OutputDev for SVGOutput<'_> {
+    fn begin_page(
+        &mut self,
+        _page_num: u32,
+        media_box: &MediaBox,
+        art_box: Option<(f64, f64, f64, f64)>,
+    ) -> Result<(), OutputError> {
         let ver = 1.1;
-        write!(self.file, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n")?;
+        writeln!(self.file, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>")?;
         if ver == 1.1 {
-            write!(self.file, r#"<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">"#)?;
+            write!(
+                self.file,
+                r#"<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">"#
+            )?;
         } else {
-            write!(self.file, r#"<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">"#)?;
+            write!(
+                self.file,
+                r#"<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">"#
+            )?;
         }
         if let Some(art_box) = art_box {
             let width = art_box.2 - art_box.0;
@@ -1960,39 +2315,52 @@ impl<'a> OutputDev for SVGOutput<'a> {
             let height = media_box.ury - media_box.lly;
             write!(self.file, "<svg width=\"{}\" height=\"{}\" xmlns=\"http://www.w3.org/2000/svg\" version=\"{}\" viewBox='{} {} {} {}'>", width, height, ver, media_box.llx, media_box.lly, width, height)?;
         }
-        write!(self.file, "\n")?;
+        writeln!(self.file)?;
         type Mat = Transform;
 
         let ctm = Mat::create_scale(1., -1.).post_translate(vec2(0., media_box.ury));
-        write!(self.file, "<g transform='matrix({}, {}, {}, {}, {}, {})'>\n",
-               ctm.m11,
-               ctm.m12,
-               ctm.m21,
-               ctm.m22,
-               ctm.m31,
-               ctm.m32,
+        writeln!(
+            self.file,
+            "<g transform='matrix({}, {}, {}, {}, {}, {})'>",
+            ctm.m11, ctm.m12, ctm.m21, ctm.m22, ctm.m31, ctm.m32,
         )?;
         Ok(())
     }
-    fn end_page(&mut self) -> Result<(), OutputError>{
-        write!(self.file, "</g>\n")?;
+    fn end_page(&mut self) -> Result<(), OutputError> {
+        writeln!(self.file, "</g>")?;
         write!(self.file, "</svg>")?;
         Ok(())
     }
-    fn output_character(&mut self, _trm: &Transform, _width: f64, _spacing: f64, _font_size: f64, _char: &str) -> Result<(), OutputError>{
+    fn output_character(
+        &mut self,
+        _trm: &Transform,
+        _width: f64,
+        _spacing: f64,
+        _font_size: f64,
+        _char: &str,
+    ) -> Result<(), OutputError> {
         Ok(())
     }
-    fn begin_word(&mut self) -> Result<(), OutputError> {Ok(())}
-    fn end_word(&mut self) -> Result<(), OutputError> {Ok(())}
-    fn end_line(&mut self) -> Result<(), OutputError> {Ok(())}
-    fn fill(&mut self, ctm: &Transform, _colorspace: &ColorSpace, _color: &[f64], path: &Path) -> Result<(), OutputError>{
-        write!(self.file, "<g transform='matrix({}, {}, {}, {}, {}, {})'>",
-               ctm.m11,
-               ctm.m12,
-               ctm.m21,
-               ctm.m22,
-               ctm.m31,
-               ctm.m32,
+    fn begin_word(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn end_word(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn end_line(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn fill(
+        &mut self,
+        ctm: &Transform,
+        _colorspace: &ColorSpace,
+        _color: &[f64],
+        path: &Path,
+    ) -> Result<(), OutputError> {
+        write!(
+            self.file,
+            "<g transform='matrix({}, {}, {}, {}, {}, {})'>",
+            ctm.m11, ctm.m12, ctm.m21, ctm.m22, ctm.m31, ctm.m32,
         )?;
 
         /*if path.ops.len() == 1 {
@@ -2004,24 +2372,25 @@ impl<'a> OutputDev for SVGOutput<'a> {
         }*/
         let mut d = Vec::new();
         for op in &path.ops {
-            match op {
-                &PathOp::MoveTo(x, y) => { d.push(format!("M{} {}", x, y))}
-                &PathOp::LineTo(x, y) => { d.push(format!("L{} {}", x, y))},
-                &PathOp::CurveTo(x1, y1, x2, y2, x, y) => { d.push(format!("C{} {} {} {} {} {}", x1, y1, x2, y2, x, y))},
-                &PathOp::Close => { d.push(format!("Z"))},
-                &PathOp::Rect(x, y, width, height) => {
-                    d.push(format!("M{} {}", x, y));
+            match *op {
+                PathOp::MoveTo(x, y) => d.push(format!("M{x} {y}")),
+                PathOp::LineTo(x, y) => d.push(format!("L{x} {y}")),
+                PathOp::CurveTo(x1, y1, x2, y2, x, y) => {
+                    d.push(format!("C{x1} {y1} {x2} {y2} {x} {y}"));
+                }
+                PathOp::Close => d.push("Z".to_string()),
+                PathOp::Rect(x, y, width, height) => {
+                    d.push(format!("M{x} {y}"));
                     d.push(format!("L{} {}", x + width, y));
                     d.push(format!("L{} {}", x + width, y + height));
                     d.push(format!("L{} {}", x, y + height));
-                    d.push(format!("Z"));
+                    d.push("Z".to_string());
                 }
-
             }
         }
         write!(self.file, "<path d='{}' />", d.join(" "))?;
         write!(self.file, "</g>")?;
-        write!(self.file, "\n")?;
+        writeln!(self.file)?;
         Ok(())
     }
 }
@@ -2054,21 +2423,21 @@ impl<W: std::io::Write> std::fmt::Write for WriteAdapter<W> {
     }
 }
 
-impl<'a> ConvertToFmt for &'a mut dyn std::io::Write {
+impl ConvertToFmt for &mut dyn std::io::Write {
     type Writer = WriteAdapter<Self>;
     fn convert(self) -> Self::Writer {
         WriteAdapter { f: self }
     }
 }
 
-impl<'a> ConvertToFmt for &'a mut File {
+impl ConvertToFmt for &mut File {
     type Writer = WriteAdapter<Self>;
     fn convert(self) -> Self::Writer {
         WriteAdapter { f: self }
     }
 }
 
-pub struct PlainTextOutput<W: ConvertToFmt>   {
+pub struct PlainTextOutput<W: ConvertToFmt> {
     writer: W::Writer,
     last_end: f64,
     last_y: f64,
@@ -2077,10 +2446,10 @@ pub struct PlainTextOutput<W: ConvertToFmt>   {
 }
 
 impl<W: ConvertToFmt> PlainTextOutput<W> {
-    pub fn new(writer: W) -> PlainTextOutput<W> {
-        PlainTextOutput{
+    pub fn new(writer: W) -> Self {
+        Self {
             writer: writer.convert(),
-            last_end: 100000.,
+            last_end: 100_000.,
             first_char: false,
             last_y: 0.,
             flip_ctm: Transform2D::identity(),
@@ -2091,72 +2460,97 @@ impl<W: ConvertToFmt> PlainTextOutput<W> {
 /* There are some structural hints that PDFs can use to signal word and line endings:
  * however relying on these is not likely to be sufficient. */
 impl<W: ConvertToFmt> OutputDev for PlainTextOutput<W> {
-    fn begin_page(&mut self, _page_num: u32, media_box: &MediaBox, _: Option<ArtBox>) -> Result<(), OutputError> {
+    fn begin_page(
+        &mut self,
+        _page_num: u32,
+        media_box: &MediaBox,
+        _: Option<ArtBox>,
+    ) -> Result<(), OutputError> {
         self.flip_ctm = Transform2D::row_major(1., 0., 0., -1., 0., media_box.ury - media_box.lly);
         Ok(())
     }
     fn end_page(&mut self) -> Result<(), OutputError> {
         Ok(())
     }
-    fn output_character(&mut self, trm: &Transform, width: f64, _spacing: f64, font_size: f64, char: &str) -> Result<(), OutputError> {
+    fn output_character(
+        &mut self,
+        trm: &Transform,
+        width: f64,
+        _spacing: f64,
+        font_size: f64,
+        char: &str,
+    ) -> Result<(), OutputError> {
         let position = trm.post_transform(&self.flip_ctm);
         let transformed_font_size_vec = trm.transform_vector(vec2(font_size, font_size));
         // get the length of one sized of the square with the same area with a rectangle of size (x, y)
-        let transformed_font_size = (transformed_font_size_vec.x*transformed_font_size_vec.y).sqrt();
+        let transformed_font_size =
+            (transformed_font_size_vec.x * transformed_font_size_vec.y).sqrt();
         let (x, y) = (position.m31, position.m32);
-        use std::fmt::Write;
         //dlog!("last_end: {} x: {}, width: {}", self.last_end, x, width);
         if self.first_char {
             if (y - self.last_y).abs() > transformed_font_size * 1.5 {
-                write!(self.writer, "\n")?;
+                writeln!(self.writer)?;
             }
 
             // we've moved to the left and down
             if x < self.last_end && (y - self.last_y).abs() > transformed_font_size * 0.5 {
-                write!(self.writer, "\n")?;
+                writeln!(self.writer)?;
             }
 
-            if x > self.last_end + transformed_font_size * 0.1 {
-                dlog!("width: {}, space: {}, thresh: {}", width, x - self.last_end, transformed_font_size * 0.1);
+            if x > transformed_font_size.mul_add(0.1, self.last_end) {
+                dlog!(
+                    "width: {}, space: {}, thresh: {}",
+                    width,
+                    x - self.last_end,
+                    transformed_font_size * 0.1
+                );
                 write!(self.writer, " ")?;
             }
         }
         //let norm = unicode_normalization::UnicodeNormalization::nfkc(char);
-        write!(self.writer, "{}", char)?;
+        write!(self.writer, "{char}")?;
         self.first_char = false;
         self.last_y = y;
-        self.last_end = x + width * transformed_font_size;
+        self.last_end = width.mul_add(transformed_font_size, x);
         Ok(())
     }
     fn begin_word(&mut self) -> Result<(), OutputError> {
         self.first_char = true;
         Ok(())
     }
-    fn end_word(&mut self) -> Result<(), OutputError> {Ok(())}
-    fn end_line(&mut self) -> Result<(), OutputError>{
+    fn end_word(&mut self) -> Result<(), OutputError> {
+        Ok(())
+    }
+    fn end_line(&mut self) -> Result<(), OutputError> {
         //write!(self.file, "\n");
         Ok(())
     }
 }
 
-
 pub fn print_metadata(doc: &Document) {
     dlog!("Version: {}", doc.version);
-    if let Some(ref info) = get_info(&doc) {
-        for (k, v) in *info {
-            match v {
-                &Object::String(ref s, StringFormat::Literal) => { dlog!("{}: {}", pdf_to_utf8(k), pdf_to_utf8(s)); }
-                _ => {}
+    if let Some(info) = get_info(doc) {
+        for (k, v) in info {
+            if let &Object::String(ref s, StringFormat::Literal) = v {
+                dlog!("{}: {}", pdf_to_utf8(k), pdf_to_utf8(s));
             }
         }
     }
-    dlog!("Page count: {}", get::<i64>(&doc, &get_pages(&doc), b"Count"));
-    dlog!("Pages: {:?}", get_pages(&doc));
-    dlog!("Type: {:?}", get_pages(&doc).get(b"Type").and_then(|x| x.as_name()).unwrap());
+    dlog!("Page count: {}", get::<i64>(doc, get_pages(doc), b"Count"));
+    dlog!("Pages: {:?}", get_pages(doc));
+    dlog!(
+        "Type: {:?}",
+        get_pages(doc)
+            .get(b"Type")
+            .and_then(|x| x.as_name())
+            .unwrap()
+    );
 }
 
 /// Extract the text from a pdf at `path` and return a `String` with the results
-pub fn extract_text<P: std::convert::AsRef<std::path::Path>>(path: P) -> Result<String, OutputError> {
+pub fn extract_text<P: std::convert::AsRef<std::path::Path>>(
+    path: P,
+) -> Result<String, OutputError> {
     let mut s = String::new();
     {
         let mut output = PlainTextOutput::new(&mut s);
@@ -2168,13 +2562,13 @@ pub fn extract_text<P: std::convert::AsRef<std::path::Path>>(path: P) -> Result<
 }
 
 fn maybe_decrypt(doc: &mut Document) -> Result<(), OutputError> {
-    if ! doc.is_encrypted() {
+    if !doc.is_encrypted() {
         return Ok(());
     }
 
     if let Err(e) = doc.decrypt("") {
-        if let Error::Decryption(DecryptionError::IncorrectPassword) = e {
-            eprintln!("Encrypted documents must be decrypted with a password using {{extract_text|extract_text_from_mem|output_doc}}_encrypted")
+        if matches!(e, Error::Decryption(DecryptionError::IncorrectPassword)) {
+            eprintln!("Encrypted documents must be decrypted with a password using {{extract_text|extract_text_from_mem|output_doc}}_encrypted");
         }
 
         return Err(OutputError::PdfError(e));
@@ -2220,7 +2614,6 @@ pub fn extract_text_from_mem_encrypted<PW: AsRef<[u8]>>(
     Ok(s)
 }
 
-
 fn extract_text_by_page(doc: &Document, page_num: u32) -> Result<String, OutputError> {
     let mut s = String::new();
     {
@@ -2231,8 +2624,9 @@ fn extract_text_by_page(doc: &Document, page_num: u32) -> Result<String, OutputE
 }
 
 /// Extract the text from a pdf at `path` and return a `Vec<String>` with the results separately by page
-
-pub fn extract_text_by_pages<P: std::convert::AsRef<std::path::Path>>(path: P) -> Result<Vec<String>, OutputError> {
+pub fn extract_text_by_pages<P: std::convert::AsRef<std::path::Path>>(
+    path: P,
+) -> Result<Vec<String>, OutputError> {
     let mut v = Vec::new();
     {
         let mut doc = Document::load(path)?;
@@ -2246,13 +2640,16 @@ pub fn extract_text_by_pages<P: std::convert::AsRef<std::path::Path>>(path: P) -
     Ok(v)
 }
 
-pub fn extract_text_by_pages_encrypted<P: std::convert::AsRef<std::path::Path>, PW: AsRef<[u8]>>(path: P, password: PW) -> Result<Vec<String>, OutputError> {
+pub fn extract_text_by_pages_encrypted<P: std::convert::AsRef<std::path::Path>, PW: AsRef<[u8]>>(
+    path: P,
+    password: PW,
+) -> Result<Vec<String>, OutputError> {
     let mut v = Vec::new();
     {
         let mut doc = Document::load(path)?;
         doc.decrypt(password)?;
         let mut page_num = 1;
-        while let Ok(content) = extract_text_by_page(&mut doc, page_num) {
+        while let Ok(content) = extract_text_by_page(&doc, page_num) {
             v.push(content);
             page_num += 1;
         }
@@ -2274,7 +2671,10 @@ pub fn extract_text_from_mem_by_pages(buffer: &[u8]) -> Result<Vec<String>, Outp
     Ok(v)
 }
 
-pub fn extract_text_from_mem_by_pages_encrypted<PW: AsRef<[u8]>>(buffer: &[u8], password: PW) -> Result<Vec<String>, OutputError> {
+pub fn extract_text_from_mem_by_pages_encrypted<PW: AsRef<[u8]>>(
+    buffer: &[u8],
+    password: PW,
+) -> Result<Vec<String>, OutputError> {
     let mut v = Vec::new();
     {
         let mut doc = Document::load_mem(buffer)?;
@@ -2288,15 +2688,20 @@ pub fn extract_text_from_mem_by_pages_encrypted<PW: AsRef<[u8]>>(buffer: &[u8], 
     Ok(v)
 }
 
-
-fn get_inherited<'a, T: FromObj<'a>>(doc: &'a Document, dict: &'a Dictionary, key: &[u8]) -> Option<T> {
+fn get_inherited<'a, T: FromObj<'a>>(
+    doc: &'a Document,
+    dict: &'a Dictionary,
+    key: &[u8],
+) -> Option<T> {
     let o: Option<T> = get(doc, dict, key);
     if let Some(o) = o {
         Some(o)
     } else {
-        let parent = dict.get(b"Parent")
-            .and_then(|parent| parent.as_reference())
-            .and_then(|id| doc.get_dictionary(id)).ok()?;
+        let parent = dict
+            .get(b"Parent")
+            .and_then(lopdf::Object::as_reference)
+            .and_then(|id| doc.get_dictionary(id))
+            .ok()?;
         get_inherited(doc, parent, key)
     }
 }
@@ -2326,19 +2731,32 @@ pub fn output_doc(doc: &Document, output: &mut dyn OutputDev) -> Result<(), Outp
     Ok(())
 }
 
-pub fn output_doc_page(doc: &Document, output: &mut dyn OutputDev, page_num: u32) -> Result<(), OutputError> {
+pub fn output_doc_page(
+    doc: &Document,
+    output: &mut dyn OutputDev,
+    page_num: u32,
+) -> Result<(), OutputError> {
     if doc.is_encrypted() {
         eprintln!("Encrypted documents must be decrypted with a password using {{extract_text|extract_text_from_mem|output_doc}}_encrypted");
     }
     let empty_resources = Dictionary::new();
     let pages = doc.get_pages();
-    let object_id = pages.get(&page_num).ok_or(lopdf::Error::PageNumberNotFound(page_num))?;
+    let object_id = pages
+        .get(&page_num)
+        .ok_or(lopdf::Error::PageNumberNotFound(page_num))?;
     let mut p = Processor::new();
     output_doc_inner(page_num, *object_id, doc, &mut p, output, &empty_resources)?;
     Ok(())
 }
 
-fn output_doc_inner<'a>(page_num: u32, object_id: ObjectId, doc: &'a Document, p: & mut Processor<'a>, output: &mut dyn OutputDev, empty_resources: &'a Dictionary) -> Result<(), OutputError> {
+fn output_doc_inner<'a>(
+    page_num: u32,
+    object_id: ObjectId,
+    doc: &'a Document,
+    p: &mut Processor<'a>,
+    output: &mut dyn OutputDev,
+    empty_resources: &'a Dictionary,
+) -> Result<(), OutputError> {
     let page_dict = doc.get_object(object_id).unwrap().as_dict().unwrap();
     dlog!("page {} {:?}", page_num, page_dict);
     // XXX: Some pdfs lack a Resources directory
@@ -2346,11 +2764,23 @@ fn output_doc_inner<'a>(page_num: u32, object_id: ObjectId, doc: &'a Document, p
     dlog!("resources {:?}", resources);
     // pdfium searches up the page tree for MediaBoxes as needed
     let media_box: Vec<f64> = get_inherited(doc, page_dict, b"MediaBox").expect("MediaBox");
-    let media_box = MediaBox { llx: media_box[0], lly: media_box[1], urx: media_box[2], ury: media_box[3] };
-    let art_box = get::<Option<Vec<f64>>>(&doc, page_dict, b"ArtBox")
-        .map(|x| (x[0], x[1], x[2], x[3]));
+    let media_box = MediaBox {
+        llx: media_box[0],
+        lly: media_box[1],
+        urx: media_box[2],
+        ury: media_box[3],
+    };
+    let art_box =
+        get::<Option<Vec<f64>>>(doc, page_dict, b"ArtBox").map(|x| (x[0], x[1], x[2], x[3]));
     output.begin_page(page_num, &media_box, art_box)?;
-    p.process_stream(&doc, doc.get_page_content(object_id).unwrap(), resources, &media_box, output, page_num)?;
+    p.process_stream(
+        doc,
+        &doc.get_page_content(object_id).unwrap(),
+        resources,
+        &media_box,
+        output,
+        page_num,
+    )?;
     output.end_page()?;
     Ok(())
 }

--- a/src/zapfglyphnames.rs
+++ b/src/zapfglyphnames.rs
@@ -191,7 +191,6 @@ pub fn zapfdigbats_names_to_unicode(name: &str) -> Option<u16> {
         ("a88", 0x2773),
         ("a89", 0x2768),
         ("a9", 0x2720),
-
         ("a90", 0x2769),
         ("a91", 0x276c),
         ("a92", 0x276d),
@@ -205,6 +204,6 @@ pub fn zapfdigbats_names_to_unicode(name: &str) -> Option<u16> {
         ("space", 0x0020),
     ];
 
-    let result = names.binary_search_by_key(&name, |&(name,_code)| &name);
+    let result = names.binary_search_by_key(&name, |&(name, _code)| name);
     result.ok().map(|indx| names[indx].1)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -53,9 +53,7 @@ impl ExpectedText<'_> {
                 if let Err(e) = std::fs::create_dir(docs_cache) {
                     assert!(
                         (e.kind() == std::io::ErrorKind::AlreadyExists),
-                        "Failed to create directory {}, {}",
-                        docs_cache,
-                        e
+                        "Failed to create directory {docs_cache}, {e}"
                     );
                 }
             }
@@ -72,13 +70,11 @@ impl ExpectedText<'_> {
             format!("tests/docs/{filename}")
         };
         let out = extract_text(file_path)
-            .unwrap_or_else(|e| panic!("Failed to extract text from {}, {}", filename, e));
+            .unwrap_or_else(|e| panic!("Failed to extract text from {filename}, {e}"));
         println!("{out}");
         assert!(
             out.contains(text),
-            "Text {} does not contain '{}'",
-            filename,
-            text
+            "Text {filename} does not contain '{text}'"
         );
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -51,27 +51,29 @@ impl ExpectedText<'_> {
             if !std::path::Path::new(docs_cache).exists() {
                 // This might race with exists test above, but that's fine
                 if let Err(e) = std::fs::create_dir(docs_cache) {
-                    if e.kind() != std::io::ErrorKind::AlreadyExists {
-                        panic!("Failed to create directory {}, {}", docs_cache, e);
-                    }
-                } 
+                    assert!(
+                        (e.kind() == std::io::ErrorKind::AlreadyExists),
+                        "Failed to create directory {}, {}",
+                        docs_cache,
+                        e
+                    );
+                }
             }
             let file_path = format!("{}/{}", docs_cache, filename.replace(".link", ""));
             if std::path::Path::new(&file_path).exists() {
-                file_path
             } else {
-                let url = std::fs::read_to_string(format!("tests/docs/{}", filename)).unwrap();
+                let url = std::fs::read_to_string(format!("tests/docs/{filename}")).unwrap();
                 let resp = ureq::get(&url).call().unwrap();
                 let mut file = std::fs::File::create(&file_path).unwrap();
                 std::io::copy(&mut resp.into_reader(), &mut file).unwrap();
-                file_path
             }
+            file_path
         } else {
-            format!("tests/docs/{}", filename)
+            format!("tests/docs/{filename}")
         };
         let out = extract_text(file_path)
             .unwrap_or_else(|e| panic!("Failed to extract text from {}, {}", filename, e));
-        println!("{}", out);
+        println!("{out}");
         assert!(
             out.contains(text),
             "Text {} does not contain '{}'",


### PR DESCRIPTION
This PR aims to solve the following:

- "Rustify: the code-base, applying best practice patterns
  - We're getting there to please the clippy/rust-analyzer gods and have a hopefully easier to maintain code-base
  - We may get some minor perf. out of this but less likely, didn't benchmark this
  - Adds some minor tests
  - Bumps Rust edition to 2021

This PR does *NOT*:

- add/change any existing functionality to make merging it easier 