### PR TITLE
Update README link for related project pdfextract by CrossRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ assert!(out.contains("This is a small demonstration"));
 
 - https://github.com/elacin/PDFExtract/
 - https://github.com/euske/pdfminer / https://github.com/pdfminer/pdfminer.six
-- https://github.com/CrossRef/pdfextract
+- https://gitlab.com/crossref/pdfextract
 - https://github.com/VikParuchuri/marker
 - https://github.com/kermitt2/pdfalto used by [grobid](https://github.com/kermitt2/grobid/)
 - https://github.com/opendatalab/MinerU (uses PyMuPDF and pdfminer.six)


### PR DESCRIPTION
The README includes a link under the "See also" section to the related project "pdfextract" by CrossRef. This project's repository has been moved from GitHub to GitLab.

This commit updates the link from:
https://github.com/CrossRef/pdfextract
to:
https://gitlab.com/crossref/pdfextract