### PR TITLE
Use the `tracing` library to log instead of `println!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lopdf = {version = "0.34", default-features = false, features = ["nom_parser"]}
 postscript = "0.14"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"
+tracing = "0.1.41"
 
 [dev-dependencies]
 ureq = "2.6.2"


### PR DESCRIPTION
Closes #114

Replaces all instances of `println!` with `tracing::debug!` and `eprintln!` with `tracing::error!`