### PR TITLE
chore: update lopdf version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = true
 adobe-cmap-parser = "0.4.1"
 encoding_rs = "0.8.34"
 euclid = "0.20.5"
-lopdf = {version = "0.36", default-features = false}
+lopdf = {version = "0.38", default-features = false}
 postscript = "0.14"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"


### PR DESCRIPTION
lopdf 0.36 gives empty text on many pdfs due a problem with encryption on non passwords pdfs, fixed on 0.38