### PR TITLE
Fix AES-encrypted PDF decryption and add StandardEncoding support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = true
 adobe-cmap-parser = "0.4.1"
 encoding_rs = "0.8.34"
 euclid = "0.20.5"
-lopdf = {version = "0.38", default-features = false}
+lopdf = {version = "0.39", default-features = false}
 postscript = "0.14"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"


### PR DESCRIPTION
## Summary

- Upgrade lopdf from 0.38 to 0.39 and use `load_with_password`/`load_mem_with_password` for single-pass decryption instead of the two-step `load` + `maybe_decrypt` approach
- Add `StandardEncoding` to `encoding_to_unicode_table` — the encoding table already exists in `encodings.rs` but was missing from the match, causing a panic on PDFs that use it

## Problem

lopdf 0.38's `load()`/`load_mem()` silently decrypts empty-password AES-encrypted PDFs during loading. When `maybe_decrypt()` then calls `doc.decrypt("")` on the already-decrypted data, the plaintext doesn't satisfy AES block-size requirements, causing `PdfError(Decryption(InvalidCipherTextLength))`.

## Solution

lopdf 0.39 provides `load_with_password()`/`load_mem_with_password()` which handle decryption correctly in a single pass, making the separate `maybe_decrypt()` function unnecessary.

A `check_password_error` helper preserves the existing UX: when users call `extract_text()` on a password-protected PDF, the error message directing them to the `_encrypted` variants is still logged.

## Changes

- `Cargo.toml`: bump lopdf 0.38 → 0.39
- `src/lib.rs`:
  - Remove `maybe_decrypt()` and unused `DecryptionError` import
  - Replace all `Document::load()` + `maybe_decrypt()`/`decrypt()` with `Document::load_with_password()`
  - Replace all `Document::load_mem()` + `maybe_decrypt()`/`decrypt()` with `Document::load_mem_with_password()`
  - Add `check_password_error()` to preserve the old error logging for password-protected PDFs
  - Guard `output_doc_encrypted` with `if doc.is_encrypted()` before calling `decrypt()`
  - Add `b"StandardEncoding" => encodings::STANDARD_ENCODING` to `encoding_to_unicode_table`

## Test plan

- [x] All existing tests pass (`extract_expected_text`, `extract_all_docs`)
- [x] Verified fix against real-world AES-encrypted PDF (Canadian Tire Financial Services eStatement)
- [x] `cargo build` clean (no new warnings)