### PR TITLE
Added support for wasm compile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+  wasm-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install wasm target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Check wasm build
+      run: cargo check --target wasm32-unknown-unknown --lib --verbose
   semver:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = true
 adobe-cmap-parser = "0.4.1"
 encoding_rs = "0.8.34"
 euclid = "0.20.5"
-lopdf = {version = "0.38", default-features = false}
+lopdf = {version = "0.38", default-features = false, features = ["wasm_js"]}
 postscript = "0.14"
 type1-encoding-parser = "0.1.0"
 unicode-normalization = "0.1.19"


### PR DESCRIPTION
This PR fixes `wasm32-unknown-unknown` compilation for pdf-extract and adds CI coverage to prevent regressions.

## Problem

Building for wasm32-unknown-unknown failed through the dependency chain pdf-extract -> lopdf -> getrandom, where getrandom requires wasm JS backend support for this
target.

## Changes

- Updated lopdf dependency in Cargo.toml to enable wasm_js:
  - lopdf = { version = "0.38", default-features = false, features = ["wasm_js"] }
- Added a new GitHub Actions job wasm-check in .github/workflows/rust.yml:
  - installs wasm32-unknown-unknown
  - runs cargo check --target wasm32-unknown-unknown --lib --verbose