### PR TITLE
Skip malformed path operators instead of panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ extern crate lopdf;
 
 use adobe_cmap_parser::{ByteMapping, CodeRange, CIDRange};
 use encoding_rs::UTF_16BE;
-use lopdf::content::Content;
+use lopdf::content::{Content, Operation};
 pub use lopdf::*;
 use euclid::*;
 use lopdf::encryption::DecryptionError;
@@ -1238,6 +1238,36 @@ fn as_num(o: &Object) -> f64 {
     }
 }
 
+fn operands_as_nums(operation: &Operation, expected: usize) -> Option<Vec<f64>> {
+    if operation.operands.len() < expected {
+        warn!(
+            "Skipping malformed PDF operator '{}' with {} operands; expected {}",
+            operation.operator,
+            operation.operands.len(),
+            expected
+        );
+        return None;
+    }
+
+    let mut nums = Vec::with_capacity(expected);
+    for operand in operation.operands.iter().take(expected) {
+        match operand {
+            &Object::Integer(i) => nums.push(i as f64),
+            &Object::Real(f) => nums.push(f.into()),
+            _ => {
+                warn!(
+                    "Skipping malformed PDF operator '{}' with non-numeric operand {:?}",
+                    operation.operator,
+                    operand
+                );
+                return None;
+            }
+        }
+    }
+
+    Some(nums)
+}
+
 #[derive(Clone)]
 struct TextState<'a>
 {
@@ -1796,44 +1826,61 @@ impl<'a> Processor<'a> {
                     apply_state(doc, &mut gs, state);
                 }
                 "i" => { dlog!("unhandled graphics state flattness operator {:?}", operation); }
-                "w" => { gs.line_width = as_num(&operation.operands[0]); }
+                "w" => {
+                    if let Some(nums) = operands_as_nums(&operation, 1) {
+                        gs.line_width = nums[0];
+                    }
+                }
                 "J" | "j" | "M" | "d" | "ri"  => { dlog!("unknown graphics state operator {:?}", operation); }
-                "m" => { path.ops.push(PathOp::MoveTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
-                "l" => { path.ops.push(PathOp::LineTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
+                "m" => {
+                    if let Some(nums) = operands_as_nums(&operation, 2) {
+                        path.ops.push(PathOp::MoveTo(nums[0], nums[1]))
+                    }
+                }
+                "l" => {
+                    if let Some(nums) = operands_as_nums(&operation, 2) {
+                        path.ops.push(PathOp::LineTo(nums[0], nums[1]))
+                    }
+                }
                 "c" => {
-                    path.ops.push(PathOp::CurveTo(
-                        as_num(&operation.operands[0]),
-                        as_num(&operation.operands[1]),
-                        as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3]),
-                        as_num(&operation.operands[4]),
-                        as_num(&operation.operands[5])))
+                    if let Some(nums) = operands_as_nums(&operation, 6) {
+                        path.ops.push(PathOp::CurveTo(
+                            nums[0],
+                            nums[1],
+                            nums[2],
+                            nums[3],
+                            nums[4],
+                            nums[5]))
+                    }
                 }
                 "v" => {
-                    let (x, y) = path.current_point();
-                    path.ops.push(PathOp::CurveTo(
-                        x,
-                        y,
-                        as_num(&operation.operands[0]),
-                        as_num(&operation.operands[1]),
-                        as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3])))
+                    if let Some(nums) = operands_as_nums(&operation, 4) {
+                        let (x, y) = path.current_point();
+                        path.ops.push(PathOp::CurveTo(
+                            x,
+                            y,
+                            nums[0],
+                            nums[1],
+                            nums[2],
+                            nums[3]))
+                    }
                 }
                 "y" => {
-                    path.ops.push(PathOp::CurveTo(
-                        as_num(&operation.operands[0]),
-                        as_num(&operation.operands[1]),
-                        as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3]),
-                        as_num(&operation.operands[2]),
-                        as_num(&operation.operands[3])))
+                    if let Some(nums) = operands_as_nums(&operation, 4) {
+                        path.ops.push(PathOp::CurveTo(
+                            nums[0],
+                            nums[1],
+                            nums[2],
+                            nums[3],
+                            nums[2],
+                            nums[3]))
+                    }
                 }
                 "h" => { path.ops.push(PathOp::Close) }
                 "re" => {
-                    path.ops.push(PathOp::Rect(as_num(&operation.operands[0]),
-                                               as_num(&operation.operands[1]),
-                                               as_num(&operation.operands[2]),
-                                               as_num(&operation.operands[3])))
+                    if let Some(nums) = operands_as_nums(&operation, 4) {
+                        path.ops.push(PathOp::Rect(nums[0], nums[1], nums[2], nums[3]))
+                    }
                 }
                 "s" | "f*" | "B" | "B*" | "b" => {
                     dlog!("unhandled path op {:?}", operation);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 use log::info;
 use pdf_extract::extract_text;
+use std::io::Write;
 use test_log::test;
 // Shorthand for creating ExpectedText
 // example: expected!("atomic.pdf", "Atomic Data");
@@ -32,6 +33,60 @@ fn extract_all_docs() {
         let filename = path.file_name().unwrap().to_string_lossy();
         expected!(&filename, "").test();
     }
+}
+
+#[test]
+fn ignores_malformed_curve_operator() {
+    let pdf = minimal_pdf_with_content(
+        b"BT /F1 12 Tf 72 720 Td (Curve operand regression) Tj ET\n0 0 m\nc\nS\n",
+    );
+    let path = std::env::temp_dir().join(format!(
+        "pdf_extract_malformed_curve_{}.pdf",
+        std::process::id()
+    ));
+    let mut file = std::fs::File::create(&path).unwrap();
+    file.write_all(&pdf).unwrap();
+
+    let out = extract_text(&path).unwrap();
+    std::fs::remove_file(&path).unwrap();
+    assert!(out.contains("Curve operand regression"), "output was: {}", out);
+}
+
+fn minimal_pdf_with_content(content: &[u8]) -> Vec<u8> {
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>".to_vec(),
+        format!("<< /Length {} >>\nstream\n", content.len()).into_bytes(),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+    ];
+    objects[3].extend_from_slice(content);
+    objects[3].extend_from_slice(b"endstream");
+
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::new();
+    for (idx, object) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n", idx + 1).as_bytes());
+        pdf.extend_from_slice(object);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", offset).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            objects.len() + 1,
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    pdf
 }
 
 // data structure to make it easy to check if certain files are correctly parsed


### PR DESCRIPTION
## Summary

This prevents malformed path-painting operations from panicking the extractor when their operands are missing or non-numeric.

The concrete failure I hit was a PDF containing a `c` cubic Bézier path operator with zero operands. The old code indexed `operation.operands[0]` directly and aborted with an index-out-of-bounds panic. The same direct indexing pattern also existed for related path operators, so this patch guards the shared numeric operand conversion and skips malformed path operations with a warning.

## Changes

- Add `operands_as_nums` helper for guarded numeric operand extraction.
- Use it for path/graphics operators `w`, `m`, `l`, `c`, `v`, `y`, and `re`.
- Add a regression test that builds a minimal PDF containing text plus a malformed bare `c` operator, verifying text extraction still succeeds.

## Validation

- `cargo test`
- Confirmed the real failing one-page PDF no longer aborts; it now logs:
  `Skipping malformed PDF operator 'c' with 0 operands; expected 6`
