### PR TITLE
Bump to lopdf 0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = true
 adobe-cmap-parser = "0.4.1"
 encoding_rs = "0.8.34"
 euclid = "0.20.5"
-lopdf = {version = "0.39", default-features = false, features = ["wasm_js"]}
+lopdf = {version = "0.42", default-features = false, features = ["wasm_js"]}
 postscript = "0.14"
 type1-encoding-parser = "0.1.1"
 unicode-normalization = "0.1.19"


### PR DESCRIPTION
lopdf 0.35 to 0.40 carry a performance regression: ([J-F-Liu/lopdf@87f4204](https://github.com/J-F-Liu/lopdf/commit/87f4204fc1ee156e3bbedfead335c7e3ba312cac): "Removes nom_locate dependency to fix a performance regression introduced in v0.35.0.").

Measured on a real 78-page, ~38k-object tagged PDF: Document::load drops from ~11s to ~1s.

No source changes needed AFAIK, the bump seems to compile cleanly, and text extraction output is unchanged.