### PR TITLE
Reset font cache per page to fix cross-page resource-name reuse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2401,6 +2401,11 @@ pub fn output_doc_page(doc: &Document, output: &mut dyn OutputDev, page_num: u32
 fn output_doc_inner<'a>(page_num: u32, object_id: ObjectId, doc: &'a Document, p: & mut Processor<'a>, output: &mut dyn OutputDev, empty_resources: &'a Dictionary) -> Result<(), OutputError> {
     let page_dict = doc.get_object(object_id).unwrap().as_dict().unwrap();
     dlog!("page {} {:?}", page_num, page_dict);
+    // Font resource names (e.g. /F0) are only unique within a page's resource
+    // dictionary; the same name can map to a different font on the next page.
+    // Reset the font cache per page so a stale entry from an earlier page isn't
+    // reused, which would decode text with the wrong font's ToUnicode CMap.
+    p.font_table.clear();
     // XXX: Some pdfs lack a Resources directory
     let resources = get_inherited(doc, page_dict, b"Resources").unwrap_or(empty_resources);
     dlog!("resources {:?}", resources);


### PR DESCRIPTION
Fixes #151.

`font_table` is keyed by font-resource name (`/F0`, `/F1`, …), which is only unique within a single page's resource dictionary — typst, for example, reassigns those names per page in first-use order. Since 0.12 the cache lives on `Processor` for the whole document, so a name resolved on one page gets reused on a later page where it maps to a different font, and that page's text is decoded through the wrong `/ToUnicode` CMap (it comes out as a substitution cipher). In 0.10 the cache was a per-page local, so this didn't happen.

This clears the cache at the start of each page in `output_doc_inner`.

Minimal reproduction (two-page typst PDF; `cargo run` garbles page 2 on 0.12, clean on 0.10): https://github.com/padamson/pdf-extract-typst-repro

Verified that the fix restores correct extraction on that repro and on a real 419-page typst-generated book, and the existing test suite still passes.

I put the reset in `output_doc_inner` rather than `process_stream` because the latter recurses for Form XObjects, where keeping the within-page cache is correct. Happy to move it if the hayro backend work (#138) changes where this belongs.
