### PR TITLE
fix: guard content-stream operators against missing operands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,21 @@ macro_rules! dlog {
     //($($t:tt)*) => { println!($($t)*) }
 }
 
+// Guards content-stream operators against missing operands. A PDF content
+// stream may legally emit an operator with fewer operands than the parser
+// indexes below; without this guard pdf-extract panics with an out-of-bounds
+// index and aborts the whole extract. When the operand count is wrong the
+// malformed operator is logged and skipped (the enclosing loop's `continue`).
+macro_rules! require_operands {
+    ($slot:expr, $n:expr, $op:expr) => {
+        if $slot.operands.len() < $n {
+            dlog!("{} has too few operands ({} < {})",
+                  $slot.operator, $slot.operands.len(), $n);
+            continue;
+        }
+    };
+}
+
 fn get_info(doc: &Document) -> Option<&Dictionary> {
     match doc.trailer.get(b"Info") {
         Ok(&Object::Reference(ref id)) => {
@@ -1586,7 +1601,7 @@ impl<'a> Processor<'a> {
                 font_size: std::f64::NAN,
                 character_spacing: 0.,
                 word_spacing: 0.,
-                horizontal_scaling: 100. / 100.,
+                horizontal_scaling: 1.,
                 leading: 0.,
                 rise: 0.,
                 tm: Transform2D::identity(),
@@ -1620,7 +1635,7 @@ impl<'a> Processor<'a> {
                     gs.ts.tm = tlm;
                 }
                 "cm" => {
-                    assert!(operation.operands.len() == 6);
+                    require_operands!(operation, 6, "cm");
                     let m = Transform2D::row_major(as_num(&operation.operands[0]),
                                                    as_num(&operation.operands[1]),
                                                    as_num(&operation.operands[2]),
@@ -1631,11 +1646,19 @@ impl<'a> Processor<'a> {
                     dlog!("matrix {:?}", gs.ctm);
                 }
                 "CS" => {
-                    let name = operation.operands[0].as_name().unwrap();
+                    require_operands!(operation, 1, "CS");
+                    let name = match operation.operands[0].as_name() {
+                        Ok(n) => n,
+                        Err(_) => { dlog!("CS has non-name operand {:?}", operation.operands[0]); continue; }
+                    };
                     gs.stroke_colorspace = make_colorspace(doc, name, resources);
                 }
                 "cs" => {
-                    let name = operation.operands[0].as_name().unwrap();
+                    require_operands!(operation, 1, "cs");
+                    let name = match operation.operands[0].as_name() {
+                        Ok(n) => n,
+                        Err(_) => { dlog!("cs has non-name operand {:?}", operation.operands[0]); continue; }
+                    };
                     gs.fill_colorspace = make_colorspace(doc, name, resources);
                 }
                 "SC" | "SCN" => {
@@ -1654,6 +1677,7 @@ impl<'a> Processor<'a> {
                     dlog!("unhandled color operation {:?}", operation);
                 }
                 "TJ" => {
+                    require_operands!(operation, 1, "TJ");
                     match operation.operands[0] {
                         Object::Array(ref array) => {
                             for e in array {
@@ -1687,28 +1711,37 @@ impl<'a> Processor<'a> {
                     }
                 }
                 "Tj" => {
+                    require_operands!(operation, 1, "Tj");
                     match operation.operands[0] {
                         Object::String(ref s, _) => {
                             show_text(&mut gs, s, &tlm, &flip_ctm, output)?;
                         }
-                        _ => { panic!("unexpected Tj operand {:?}", operation) }
+                        _ => { dlog!("unexpected Tj operand {:?}", operation); }
                     }
                 }
                 "Tc" => {
+                    require_operands!(operation, 1, "Tc");
                     gs.ts.character_spacing = as_num(&operation.operands[0]);
                 }
                 "Tw" => {
+                    require_operands!(operation, 1, "Tw");
                     gs.ts.word_spacing = as_num(&operation.operands[0]);
                 }
                 "Tz" => {
+                    require_operands!(operation, 1, "Tz");
                     gs.ts.horizontal_scaling = as_num(&operation.operands[0]) / 100.;
                 }
                 "TL" => {
+                    require_operands!(operation, 1, "TL");
                     gs.ts.leading = as_num(&operation.operands[0]);
                 }
                 "Tf" => {
+                    require_operands!(operation, 2, "Tf");
                     let fonts: &Dictionary = get(&doc, resources, b"Font");
-                    let name = operation.operands[0].as_name().unwrap();
+                    let name = match operation.operands[0].as_name() {
+                        Ok(n) => n,
+                        Err(_) => { dlog!("Tf has non-name operand {:?}", operation.operands[0]); continue; }
+                    };
                     let font = self.font_table.entry(name.to_owned()).or_insert_with(|| make_font(doc, get::<&Dictionary>(doc, fonts, name))).clone();
                     {
                         /*let file = font.get_descriptor().and_then(|desc| desc.get_file());
@@ -1725,10 +1758,11 @@ impl<'a> Processor<'a> {
                     dlog!("font {} size: {} {:?}", pdf_to_utf8(name), gs.ts.font_size, operation);
                 }
                 "Ts" => {
+                    require_operands!(operation, 1, "Ts");
                     gs.ts.rise = as_num(&operation.operands[0]);
                 }
                 "Tm" => {
-                    assert!(operation.operands.len() == 6);
+                    require_operands!(operation, 6, "Tm");
                     tlm = Transform2D::row_major(as_num(&operation.operands[0]),
                                                  as_num(&operation.operands[1]),
                                                  as_num(&operation.operands[2]),
@@ -1744,7 +1778,7 @@ impl<'a> Processor<'a> {
                    tx and ty are numbers expressed in unscaled text space units.
                    More precisely, this operator performs the following assignments:
                  */
-                    assert!(operation.operands.len() == 2);
+                    require_operands!(operation, 2, "Td");
                     let tx = as_num(&operation.operands[0]);
                     let ty = as_num(&operation.operands[1]);
                     dlog!("translation: {} {}", tx, ty);
@@ -1759,7 +1793,7 @@ impl<'a> Processor<'a> {
                     /* Move to the start of the next line, offset from the start of the current line by (tx , ty ).
                    As a side effect, this operator sets the leading parameter in the text state.
                  */
-                    assert!(operation.operands.len() == 2);
+                    require_operands!(operation, 2, "TD");
                     let tx = as_num(&operation.operands[0]);
                     let ty = as_num(&operation.operands[1]);
                     dlog!("translation: {} {}", tx, ty);
@@ -1790,17 +1824,22 @@ impl<'a> Processor<'a> {
                     }
                 }
                 "gs" => {
+                    require_operands!(operation, 1, "gs");
                     let ext_gstate: &Dictionary = get(doc, resources, b"ExtGState");
-                    let name = operation.operands[0].as_name().unwrap();
+                    let name = match operation.operands[0].as_name() {
+                        Ok(n) => n,
+                        Err(_) => { dlog!("gs has non-name operand {:?}", operation.operands[0]); continue; }
+                    };
                     let state: &Dictionary = get(doc, ext_gstate, name);
                     apply_state(doc, &mut gs, state);
                 }
                 "i" => { dlog!("unhandled graphics state flattness operator {:?}", operation); }
-                "w" => { gs.line_width = as_num(&operation.operands[0]); }
+                "w" => { require_operands!(operation, 1, "w"); gs.line_width = as_num(&operation.operands[0]); }
                 "J" | "j" | "M" | "d" | "ri"  => { dlog!("unknown graphics state operator {:?}", operation); }
-                "m" => { path.ops.push(PathOp::MoveTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
-                "l" => { path.ops.push(PathOp::LineTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
+                "m" => { require_operands!(operation, 2, "m"); path.ops.push(PathOp::MoveTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
+                "l" => { require_operands!(operation, 2, "l"); path.ops.push(PathOp::LineTo(as_num(&operation.operands[0]), as_num(&operation.operands[1]))) }
                 "c" => {
+                    require_operands!(operation, 6, "c");
                     path.ops.push(PathOp::CurveTo(
                         as_num(&operation.operands[0]),
                         as_num(&operation.operands[1]),
@@ -1810,6 +1849,7 @@ impl<'a> Processor<'a> {
                         as_num(&operation.operands[5])))
                 }
                 "v" => {
+                    require_operands!(operation, 4, "v");
                     let (x, y) = path.current_point();
                     path.ops.push(PathOp::CurveTo(
                         x,
@@ -1820,6 +1860,7 @@ impl<'a> Processor<'a> {
                         as_num(&operation.operands[3])))
                 }
                 "y" => {
+                    require_operands!(operation, 4, "y");
                     path.ops.push(PathOp::CurveTo(
                         as_num(&operation.operands[0]),
                         as_num(&operation.operands[1]),
@@ -1830,6 +1871,7 @@ impl<'a> Processor<'a> {
                 }
                 "h" => { path.ops.push(PathOp::Close) }
                 "re" => {
+                    require_operands!(operation, 4, "re");
                     path.ops.push(PathOp::Rect(as_num(&operation.operands[0]),
                                                as_num(&operation.operands[1]),
                                                as_num(&operation.operands[2]),
@@ -1860,8 +1902,12 @@ impl<'a> Processor<'a> {
                 "Do" => {
                     // `Do` process an entire subdocument, so we do a recursive call to `process_stream`
                     // with the subdocument content and resources
+                    require_operands!(operation, 1, "Do");
                     let xobject: &Dictionary = get(&doc, resources, b"XObject");
-                    let name = operation.operands[0].as_name().unwrap();
+                    let name = match operation.operands[0].as_name() {
+                        Ok(n) => n,
+                        Err(_) => { dlog!("Do has non-name operand {:?}", operation.operands[0]); continue; }
+                    };
                     let xf: &Stream = get(&doc, xobject, name);
                     let resources = maybe_get_obj(&doc, &xf.dict, b"Resources").and_then(|n| n.as_dict().ok()).unwrap_or(resources);
                     let contents = get_contents(xf);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
 use log::info;
+use lopdf::{Dictionary, Document, Object, Stream};
 use pdf_extract::extract_text;
 use test_log::test;
 // Shorthand for creating ExpectedText
@@ -80,4 +81,49 @@ impl ExpectedText<'_> {
             text
         );
     }
+}
+
+#[test]
+fn empty_operand_operators_are_skipped() {
+    // Craft a minimal in-memory PDF whose page content stream emits CS and w
+    // with zero operands. Both operators need one operand, and before the
+    // guard this made pdf-extract panic in `process_stream` with
+    // "index out of bounds: the len is 0 but the index is 0". The fix must
+    // skip such malformed operators and return Ok instead of aborting.
+    let mut doc = Document::new();
+
+    // Bare operators with missing operands: CS (colorspace) and w (line width).
+    let content = Stream::new(Dictionary::new(), b"BT\nCS\nw\nET\n".to_vec());
+    let content_id = doc.add_object(content);
+
+    let mut page = Dictionary::new();
+    page.set("Type", Object::Name(b"Page".to_vec()));
+    page.set("MediaBox", Object::Array(vec![
+        Object::Integer(0),
+        Object::Integer(0),
+        Object::Integer(612),
+        Object::Integer(792),
+    ]));
+    page.set("Contents", Object::Reference(content_id));
+    page.set("Resources", Object::Dictionary(Dictionary::new()));
+    let page_id = doc.add_object(Object::Dictionary(page));
+
+    let mut pages = Dictionary::new();
+    pages.set("Type", Object::Name(b"Pages".to_vec()));
+    pages.set("Kids", Object::Array(vec![Object::Reference(page_id)]));
+    pages.set("Count", Object::Integer(1));
+    let pages_id = doc.add_object(Object::Dictionary(pages));
+
+    let mut catalog = Dictionary::new();
+    catalog.set("Type", Object::Name(b"Catalog".to_vec()));
+    catalog.set("Pages", Object::Reference(pages_id));
+    let catalog_id = doc.add_object(Object::Dictionary(catalog));
+    doc.trailer.set("Root", Object::Reference(catalog_id));
+
+    let mut bytes = Vec::new();
+    doc.save_to(&mut bytes).expect("serialize crafted PDF");
+
+    let out = pdf_extract::extract_text_from_mem(&bytes)
+        .unwrap_or_else(|e| panic!("extract_text_from_mem failed on crafted PDF: {}", e));
+    assert!(out.is_empty(), "expected no text, got {:?}", out);
 }


### PR DESCRIPTION
Stops pdf-extract from panicking ('index out of bounds: len 0 index 0') when a PDF content stream emits an operator with zero (or too few) operands, e.g. a bare `CS`/colorspace operator. Currently the `process_stream` dispatch indexes `operation.operands[N]` unguarded in 23 operator arms and also uses `assert!(operands.len()==N)` plus a handful of `.as_name().unwrap()` and one `panic!`.

What this PR does
- Adds a `require_operands!` macro that logs and skips an operator whose operand count is below expectation, applied to the 23 indexing arms (cm, CS, cs, TJ, Tj, Tc, Tw, Tz, TL, Tf, Ts, Tm, Td, TD, gs, w, m, l, c, v, y, re, Do).
- Removes the now-redundant asserts in cm, Tm, Td, TD.
- Converts the five `.as_name().unwrap()` sites (CS, cs, Tf, gs, Do) and the Tj `panic!` to panic-free log-and-skip.
- Adds a self-contained regression test (lopdf-built page whose content stream emits CS and w with zero operands, asserting extract_text_from_mem returns Ok).
- Fixes a clippy deny-level `eq_op` on the default `horizontal_scaling` (100./100. -> 1.).

Verification
- cargo build OK; cargo test 3 passed / 0 failed; cargo clippy --all-targets exit 0 (no new warnings).
- A real-world PDF that previously aborted extraction here now extracts cleanly.

Notes
- `as_num` still panics on a present-but-wrong-typed numeric operand; left unchanged on purpose to keep this PR focused on the empty/undersupplied-operand class. Fixing that would be a separate change.