### PR TITLE
Bump lopdf to 0.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = true
 adobe-cmap-parser = "0.4.1"
 encoding_rs = "0.8.34"
 euclid = "0.20.5"
-lopdf = {version = "0.42", default-features = false, features = ["wasm_js"]}
+lopdf = {version = "0.44", default-features = false, features = ["wasm_js"]}
 postscript = "0.14"
 type1-encoding-parser = "0.1.1"
 unicode-normalization = "0.1.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2410,7 +2410,7 @@ fn output_doc_inner<'a>(page_num: u32, object_id: ObjectId, doc: &'a Document, p
     let art_box = get::<Option<Vec<f64>>>(&doc, page_dict, b"ArtBox")
         .map(|x| (x[0], x[1], x[2], x[3]));
     output.begin_page(page_num, &media_box, art_box)?;
-    p.process_stream(&doc, doc.get_page_content(object_id).unwrap(), resources, &media_box, output, page_num)?;
+    p.process_stream(&doc, doc.get_page_content(object_id), resources, &media_box, output, page_num)?;
     output.end_page()?;
     Ok(())
 }


### PR DESCRIPTION
lopdf 0.44 made `ttf-parser` an **optional** dependency (behind the `font_embedding` feature, off by default). Since pdf-extract already uses `default-features = false`, this bump removes `ttf-parser` (flagged unmaintained by RUSTSEC-2026-0192) from downstream dependency trees entirely — verified with `cargo tree -i ttf-parser` (no match).

One small API adaptation was needed: `Document::get_page_content` now returns `Vec<u8>` directly instead of a `Result`.

`cargo test` passes (2/2).